### PR TITLE
feat: Individual exercise tracking with per-exercise checkboxes and YouTube tutorials (#40)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -22,8 +22,14 @@ export default function App() {
         await initDatabase();
         setDbReady(true);
       } catch (err: any) {
-        console.error('DB init failed:', err);
-        setError(err?.message ?? 'Unknown error during database init');
+        console.error('[App] DB init failed:', err);
+        // Build a readable detail string: message + first 8 stack lines  (#34)
+        const stackLines = (err?.stack as string | undefined)
+          ?.split('\n')
+          .slice(0, 8)
+          .join('\n');
+        const detail = [err?.message, stackLines].filter(Boolean).join('\n\n');
+        setError(detail || 'Unknown error during database initialisation');
       }
     })();
   }, []);
@@ -32,7 +38,7 @@ export default function App() {
     return (
       <View style={styles.splash}>
         <Text style={styles.errorText}>❌ Failed to initialise database</Text>
-        <Text style={styles.errorDetail}>{error}</Text>
+        <Text style={styles.errorDetail} selectable>{error}</Text>
       </View>
     );
   }

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,6 +1,11 @@
 /**
  * Database layer for the 7-Day Rolling Window architecture.
  *
+ * Additional fix:
+ *   Old-schema reset — if daily_log already exists from a previous app version
+ *   without the 'date' column, the DB is deleted and recreated before migrations
+ *   run, avoiding "no such column: date" on first launch after an upgrade.
+ *
  * Key concepts:
  *   - app_state stores the app_start_date (ISO date string, set once on first launch)
  *   - weekly_template holds 7 base rows indexed by JavaScript day-of-week (0=Sun…6=Sat)
@@ -142,6 +147,49 @@ async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {
 }
 
 // ─────────────────────────────────────────────
+// Old-schema reset helper
+// ─────────────────────────────────────────────
+
+/**
+ * Checks whether daily_log already exists with an INCOMPATIBLE schema (i.e.
+ * from a previous app version that used different column names like
+ * day_number, target_weight, etc.).
+ *
+ * If an incompatible table is detected, the entire database file is deleted
+ * via expo-sqlite's built-in API and a fresh connection is returned, allowing
+ * the migration runner to rebuild the schema from scratch.
+ *
+ * Returns the same `db` reference if the schema is compatible or the table
+ * doesn't exist yet, otherwise returns a brand-new open database handle.
+ */
+async function resetIfIncompatibleSchema(
+  db: SQLite.SQLiteDatabase
+): Promise<SQLite.SQLiteDatabase> {
+  // PRAGMA table_info returns one row per column; empty means table absent.
+  const columns = await db.getAllAsync<{ name: string }>(
+    'PRAGMA table_info(daily_log)'
+  );
+
+  // Table doesn't exist yet — fresh install, nothing to reset.
+  if (columns.length === 0) return db;
+
+  const hasDateColumn = columns.some((c) => c.name === 'date');
+  if (hasDateColumn) return db; // Compatible schema ✓
+
+  // Old incompatible schema detected → nuke and restart.
+  console.warn(
+    '[DB] Incompatible daily_log schema detected (missing "date" column). ' +
+    'Deleting old database and starting fresh…'
+  );
+  await db.closeAsync();
+  await SQLite.deleteDatabaseAsync(DB_NAME);
+  console.log('[DB] Old database deleted. Opening fresh database…');
+  const freshDb = await SQLite.openDatabaseAsync(DB_NAME);
+  await freshDb.execAsync('PRAGMA journal_mode = WAL;');
+  return freshDb;
+}
+
+// ─────────────────────────────────────────────
 // Rolling schedule sync — internal impl  (#37)
 // ─────────────────────────────────────────────
 
@@ -254,11 +302,16 @@ export async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (_db) return _db;
 
   console.log('[DB] Opening database…');
-  const db = await SQLite.openDatabaseAsync(DB_NAME);
+  let db = await SQLite.openDatabaseAsync(DB_NAME);
 
   try {
     // Enable WAL for better concurrent reads
     await db.execAsync('PRAGMA journal_mode = WAL;');
+
+    // Detect and handle an old incompatible schema left from a previous build.
+    // If daily_log exists without the 'date' column the DB file is wiped and
+    // a fresh connection is reassigned before migrations run.
+    db = await resetIfIncompatibleSchema(db);
 
     // Run versioned migrations (idempotent)  (#39)
     await runMigrations(db);

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,28 +1,27 @@
 /**
  * Database layer for the 7-Day Rolling Window architecture.
  *
- * Additional fix:
- *   Old-schema reset — if daily_log already exists from a previous app version
- *   without the 'date' column, the DB is deleted and recreated before migrations
- *   run, avoiding "no such column: date" on first launch after an upgrade.
- *
- * Key concepts:
- *   - app_state stores the app_start_date (ISO date string, set once on first launch)
- *   - weekly_template holds 7 base rows indexed by JavaScript day-of-week (0=Sun…6=Sat)
- *   - daily_log is the rolling tracker: always contains today–7 to today+7
- *   - syncRollingSchedule() must be called on every app launch
- *
- * Fixes applied:
- *   - #34  Better error propagation (stack preserved, logged to console)
+ * Fixes applied previously:
+ *   - #34  Better error propagation
  *   - #35  Multi-row INSERT replaced by versioned individual statements
- *   - #36  _db singleton only assigned after full successful init; cleaned up on failure
- *   - #37  SELECT moved outside withTransactionAsync to avoid SQLITE_BUSY on iOS
- *   - #38  _db reset to null on failure so a hot-reload or retry can re-open cleanly
+ *   - #36  _db singleton only assigned after full successful init
+ *   - #37  SELECT moved outside withTransactionAsync
+ *   - #38  _db reset to null on failure
  *   - #39  Versioned migration runner using schema_version table
+ *   - Old-schema reset: detects incompatible daily_log and wipes DB
+ *
+ * Feature additions (issue #40):
+ *   - Exercise[] JSON column on weekly_template and daily_log
+ *   - upsertExerciseCompleted() — toggles a single exercise in the JSON array
+ *   - updateTemplateExercises() — replaces the full exercise list for a weekday
+ *   - resetIfIncompatibleSchema now also detects missing exercises column
  */
 
 import * as SQLite from 'expo-sqlite';
-import { CREATE_SCHEMA_VERSION_TABLE, MIGRATIONS } from './schema';
+import { CREATE_SCHEMA_VERSION_TABLE, MIGRATIONS, Exercise } from './schema';
+
+// Re-export Exercise so screens only import from database.ts
+export type { Exercise };
 
 // ─────────────────────────────────────────────
 // Constants
@@ -31,16 +30,11 @@ import { CREATE_SCHEMA_VERSION_TABLE, MIGRATIONS } from './schema';
 const DB_NAME = 'healthtracker.db';
 const START_DATE_KEY = 'app_start_date';
 
-/** Weight added per 21-day progression cycle (kg) */
 const KG_PER_CYCLE = 5;
-/** Number of days per progression cycle */
 const CYCLE_DAYS = 21;
-/** Days to generate ahead of today */
 const DAYS_AHEAD = 7;
-/** Days of history to retain (entries older than this are pruned) */
 const DAYS_HISTORY = 7;
 
-/** Module-level singleton. Only assigned after a fully successful init. */
 let _db: SQLite.SQLiteDatabase | null = null;
 
 // ─────────────────────────────────────────────
@@ -48,15 +42,16 @@ let _db: SQLite.SQLiteDatabase | null = null;
 // ─────────────────────────────────────────────
 
 export interface WeeklyTemplateDay {
-  day_of_week: number;     // 0=Sun, 1=Mon … 6=Sat
+  day_of_week: number;
   walking_task: string;
   hammer_task: string;
   is_rest_day: boolean;
   is_meal_prep_day: boolean;
+  exercises: Exercise[];
 }
 
 export interface DailyLogEntry {
-  date: string;            // ISO date: YYYY-MM-DD
+  date: string;
   walking_task: string;
   hammer_task: string;
   walk_completed: boolean;
@@ -64,13 +59,13 @@ export interface DailyLogEntry {
   fasting_completed: boolean;
   is_rest_day: boolean;
   is_meal_prep_day: boolean;
+  exercises: Exercise[];
 }
 
 // ─────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────
 
-/** Returns today as a YYYY-MM-DD string in local time. */
 export function toISODate(date: Date = new Date()): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
@@ -78,70 +73,54 @@ export function toISODate(date: Date = new Date()): string {
   return `${y}-${m}-${d}`;
 }
 
-/** Returns a new Date offset by `days` from the given date (midnight local). */
 function addDays(date: Date, days: number): Date {
   const result = new Date(date);
   result.setDate(result.getDate() + days);
   return result;
 }
 
-/** Returns the difference in whole calendar days between two ISO date strings. */
 function daysBetween(isoA: string, isoB: string): number {
   const a = new Date(isoA);
   const b = new Date(isoB);
-  // Normalise to midnight UTC to avoid DST issues
   a.setHours(0, 0, 0, 0);
   b.setHours(0, 0, 0, 0);
   return Math.round((b.getTime() - a.getTime()) / 86_400_000);
 }
 
-/**
- * Builds the suffixed hammer_task string with the weight progression.
- *   cycle = floor(daysDiff / 21)
- *   if is_rest_day  → appends " @ Light Weight"
- *   else cycle == 0 → appends " @ Baseline"
- *   else            → appends " @ Baseline + <cycle*5>kg"
- */
-function buildHammerTask(
-  baseTask: string,
-  isRestDay: boolean,
-  daysDiff: number
-): string {
-  if (isRestDay) return `${baseTask} @ Light Weight`;
+function buildHammerTask(base: string, isRestDay: boolean, daysDiff: number): string {
+  if (isRestDay) return `${base} @ Light Weight`;
   const cycle = Math.floor(daysDiff / CYCLE_DAYS);
-  if (cycle === 0) return `${baseTask} @ Baseline`;
-  return `${baseTask} @ Baseline + ${cycle * KG_PER_CYCLE}kg`;
+  if (cycle === 0) return `${base} @ Baseline`;
+  return `${base} @ Baseline + ${cycle * KG_PER_CYCLE}kg`;
+}
+
+/** Safely parse a JSON string as Exercise[]; returns [] on any error. */
+function parseExercises(raw: string | null | undefined): Exercise[] {
+  try {
+    const parsed = JSON.parse(raw ?? '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 }
 
 // ─────────────────────────────────────────────
-// Versioned migration runner  (#39)
+// Versioned migration runner
 // ─────────────────────────────────────────────
 
-/**
- * Creates the schema_version table if needed, then applies every migration
- * that has not yet been recorded there. Each migration runs once and is
- * immediately marked as applied, so re-running initDatabase() is safe.
- */
 async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {
-  // Ensure the version-tracking table exists first
   await db.execAsync(CREATE_SCHEMA_VERSION_TABLE);
 
-  // Fetch already-applied versions
   const appliedRows = await db.getAllAsync<{ version: number }>(
     'SELECT version FROM schema_version ORDER BY version ASC'
   );
   const applied = new Set(appliedRows.map((r) => r.version));
 
-  // Apply each pending migration in order
   for (const migration of MIGRATIONS) {
     if (applied.has(migration.version)) continue;
-
     console.log(`[DB] Applying migration v${migration.version}…`);
     await db.execAsync(migration.sql);
-    await db.runAsync(
-      'INSERT INTO schema_version (version) VALUES (?)',
-      [migration.version]
-    );
+    await db.runAsync('INSERT INTO schema_version (version) VALUES (?)', [migration.version]);
     console.log(`[DB] Migration v${migration.version} applied ✓`);
   }
 }
@@ -151,32 +130,24 @@ async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {
 // ─────────────────────────────────────────────
 
 /**
- * Checks whether daily_log already exists with an INCOMPATIBLE schema (i.e.
- * from a previous app version that used different column names like
- * day_number, target_weight, etc.).
+ * Detects incompatible schemas left by previous app versions:
+ *   1. daily_log missing 'date' column (very old schema)
+ *   2. (Compatible schema — no reset needed)
  *
- * If an incompatible table is detected, the entire database file is deleted
- * via expo-sqlite's built-in API and a fresh connection is returned, allowing
- * the migration runner to rebuild the schema from scratch.
- *
- * Returns the same `db` reference if the schema is compatible or the table
- * doesn't exist yet, otherwise returns a brand-new open database handle.
+ * Note: missing 'exercises' column is handled by migrations v11/v12 via
+ * ALTER TABLE, so no reset is needed for that case.
  */
 async function resetIfIncompatibleSchema(
   db: SQLite.SQLiteDatabase
 ): Promise<SQLite.SQLiteDatabase> {
-  // PRAGMA table_info returns one row per column; empty means table absent.
   const columns = await db.getAllAsync<{ name: string }>(
     'PRAGMA table_info(daily_log)'
   );
 
-  // Table doesn't exist yet — fresh install, nothing to reset.
-  if (columns.length === 0) return db;
-
+  if (columns.length === 0) return db; // Fresh install
   const hasDateColumn = columns.some((c) => c.name === 'date');
-  if (hasDateColumn) return db; // Compatible schema ✓
+  if (hasDateColumn) return db; // Compatible
 
-  // Old incompatible schema detected → nuke and restart.
   console.warn(
     '[DB] Incompatible daily_log schema detected (missing "date" column). ' +
     'Deleting old database and starting fresh…'
@@ -190,31 +161,23 @@ async function resetIfIncompatibleSchema(
 }
 
 // ─────────────────────────────────────────────
-// Rolling schedule sync — internal impl  (#37)
+// Rolling schedule sync — internal impl
 // ─────────────────────────────────────────────
 
-/**
- * Internal implementation that accepts an explicit db reference so it can be
- * called safely during initDatabase() before _db is assigned.  (#36 / #37)
- *
- * SELECTs are performed OUTSIDE the transaction to avoid SQLITE_BUSY on iOS
- * with expo-sqlite v14+. Only write operations run inside the transaction.
- */
 async function _syncRollingSchedule(db: SQLite.SQLiteDatabase): Promise<void> {
-  // 1. Fetch app_start_date for progression maths
   const startRow = await db.getFirstAsync<{ value: string }>(
     'SELECT value FROM app_state WHERE key = ?',
     [START_DATE_KEY]
   );
   const startDateISO = startRow?.value ?? toISODate();
 
-  // 2. Fetch the weekly template (all 7 rows)
   const templateRows = await db.getAllAsync<{
     day_of_week: number;
     walking_task: string;
     hammer_task: string;
     is_rest_day: number;
     is_meal_prep_day: number;
+    exercises: string;
   }>('SELECT * FROM weekly_template');
 
   const templateMap = new Map<number, typeof templateRows[number]>();
@@ -222,23 +185,19 @@ async function _syncRollingSchedule(db: SQLite.SQLiteDatabase): Promise<void> {
     templateMap.set(row.day_of_week, row);
   }
 
-  // 3. Determine target dates: today … today+DAYS_AHEAD
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const cutoffDate = addDays(today, -DAYS_HISTORY);
   const cutoffISO = toISODate(cutoffDate);
 
-  // 4. Pre-fetch existing log dates OUTSIDE the transaction  (#37)
-  //    This avoids read calls inside withTransactionAsync which can cause
-  //    SQLITE_BUSY / "database is locked" on iOS (expo-sqlite v14+).
+  // Pre-fetch existing dates OUTSIDE the transaction (#37)
   const existingRows = await db.getAllAsync<{ date: string }>(
     'SELECT date FROM daily_log WHERE date >= ?',
     [cutoffISO]
   );
   const existingDates = new Set(existingRows.map((r) => r.date));
 
-  // Build the list of inserts needed before entering the transaction
-  type InsertParams = [string, string, string, number, number];
+  type InsertParams = [string, string, string, number, number, string];
   const inserts: InsertParams[] = [];
 
   for (let offset = 0; offset <= DAYS_AHEAD; offset++) {
@@ -247,9 +206,9 @@ async function _syncRollingSchedule(db: SQLite.SQLiteDatabase): Promise<void> {
 
     if (existingDates.has(targetISO)) continue;
 
-    const dow = targetDate.getDay(); // 0=Sun … 6=Sat
+    const dow = targetDate.getDay();
     const template = templateMap.get(dow);
-    if (!template) continue; // No template row — shouldn't happen after seeding
+    if (!template) continue;
 
     const daysDiff = daysBetween(startDateISO, targetISO);
     const hammerWithWeight = buildHammerTask(
@@ -258,46 +217,39 @@ async function _syncRollingSchedule(db: SQLite.SQLiteDatabase): Promise<void> {
       daysDiff
     );
 
+    // Parse template exercises and reset completed → false for the new day
+    const baseExercises = parseExercises(template.exercises).map((ex) => ({
+      ...ex,
+      completed: false,
+    }));
+
     inserts.push([
       targetISO,
       template.walking_task,
       hammerWithWeight,
       template.is_rest_day,
       template.is_meal_prep_day,
+      JSON.stringify(baseExercises),
     ]);
   }
 
-  // 5. Execute inserts + prune inside a single transaction (writes only)  (#37)
   await db.withTransactionAsync(async () => {
     for (const params of inserts) {
       await db.runAsync(
         `INSERT OR IGNORE INTO daily_log
-           (date, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
-         VALUES (?, ?, ?, ?, ?)`,
+           (date, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
+         VALUES (?, ?, ?, ?, ?, ?)`,
         params
       );
     }
-
-    // Prune entries older than today - DAYS_HISTORY
     await db.runAsync('DELETE FROM daily_log WHERE date < ?', [cutoffISO]);
   });
 }
 
 // ─────────────────────────────────────────────
-// Database Init  (#36 / #38)
+// Database Init
 // ─────────────────────────────────────────────
 
-/**
- * Opens the database, runs all versioned migrations, records the start date on
- * first launch, then syncs the rolling schedule.
- *
- * The module-level `_db` singleton is only assigned after the full sequence
- * succeeds. If anything throws, the connection is closed and `_db` remains
- * null so that the next call (e.g. after a dev hot-reload) can try again
- * cleanly.  (#36 / #38)
- *
- * Must be awaited before any other DB call.
- */
 export async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (_db) return _db;
 
@@ -305,18 +257,12 @@ export async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
   let db = await SQLite.openDatabaseAsync(DB_NAME);
 
   try {
-    // Enable WAL for better concurrent reads
     await db.execAsync('PRAGMA journal_mode = WAL;');
 
-    // Detect and handle an old incompatible schema left from a previous build.
-    // If daily_log exists without the 'date' column the DB file is wiped and
-    // a fresh connection is reassigned before migrations run.
     db = await resetIfIncompatibleSchema(db);
 
-    // Run versioned migrations (idempotent)  (#39)
     await runMigrations(db);
 
-    // Record start date on very first launch
     const existing = await db.getFirstAsync<{ value: string }>(
       'SELECT value FROM app_state WHERE key = ?',
       [START_DATE_KEY]
@@ -324,48 +270,31 @@ export async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
     if (!existing) {
       const today = toISODate();
       console.log(`[DB] First launch — recording start date: ${today}`);
-      await db.runAsync(
-        'INSERT INTO app_state (key, value) VALUES (?, ?)',
-        [START_DATE_KEY, today]
-      );
+      await db.runAsync('INSERT INTO app_state (key, value) VALUES (?, ?)', [START_DATE_KEY, today]);
     }
 
-    // Generate / prune the rolling window
     await _syncRollingSchedule(db);
 
-    // Only assign the singleton after full success  (#36)
     _db = db;
     console.log('[DB] Initialisation complete ✓');
   } catch (err) {
-    // Clean up the connection so a retry (e.g. after Metro hot-reload) works  (#38)
     console.error('[DB] Initialisation failed — closing connection:', err);
-    await db.closeAsync().catch((closeErr) =>
-      console.warn('[DB] Failed to close connection during cleanup:', closeErr)
-    );
-    // _db is deliberately NOT assigned — remains null for next call
-    throw err; // rethrow so App.tsx can display the real message
+    await db.closeAsync().catch((e) => console.warn('[DB] Cleanup close failed:', e));
+    throw err;
   }
 
   return _db!;
 }
 
-/** Returns the open DB instance. initDatabase() must have been called first. */
 export function getDatabase(): SQLite.SQLiteDatabase {
   if (!_db) throw new Error('Database not initialised. Call initDatabase() first.');
   return _db;
 }
 
 // ─────────────────────────────────────────────
-// Task 3 — Rolling Schedule Sync (public API)
+// Rolling Schedule Sync (public API)
 // ─────────────────────────────────────────────
 
-/**
- * Ensures the daily_log table always has entries from today up to today+7.
- * Any entry older than today-7 is pruned.
- *
- * Called automatically by initDatabase() and can be called manually on
- * app foregrounding.
- */
 export async function syncRollingSchedule(): Promise<void> {
   return _syncRollingSchedule(getDatabase());
 }
@@ -374,10 +303,6 @@ export async function syncRollingSchedule(): Promise<void> {
 // Daily Log CRUD
 // ─────────────────────────────────────────────
 
-/**
- * Fetches the log entry for a specific date.
- * Returns null if no entry exists (e.g., before the first sync).
- */
 export async function getLogByDate(date: string): Promise<DailyLogEntry | null> {
   const db = getDatabase();
   const row = await db.getFirstAsync<{
@@ -389,16 +314,13 @@ export async function getLogByDate(date: string): Promise<DailyLogEntry | null> 
     fasting_completed: number;
     is_rest_day: number;
     is_meal_prep_day: number;
+    exercises: string;
   }>('SELECT * FROM daily_log WHERE date = ?', [date]);
 
   if (!row) return null;
   return mapLogRow(row);
 }
 
-/**
- * Returns all daily_log entries in ascending date order.
- * Used by the rolling overview screen.
- */
 export async function getRollingWindow(): Promise<DailyLogEntry[]> {
   const db = getDatabase();
   const rows = await db.getAllAsync<{
@@ -410,24 +332,42 @@ export async function getRollingWindow(): Promise<DailyLogEntry[]> {
     fasting_completed: number;
     is_rest_day: number;
     is_meal_prep_day: number;
+    exercises: string;
   }>('SELECT * FROM daily_log ORDER BY date ASC');
 
   return rows.map(mapLogRow);
 }
 
-/**
- * Updates a single boolean field in daily_log for the given date.
- * fieldName must be one of: walk_completed, hammer_completed, fasting_completed
- */
 export async function upsertLogField(
   date: string,
   field: 'walk_completed' | 'hammer_completed' | 'fasting_completed',
   value: boolean
 ): Promise<void> {
   const db = getDatabase();
+  await db.runAsync(`UPDATE daily_log SET ${field} = ? WHERE date = ?`, [value ? 1 : 0, date]);
+}
+
+/**
+ * Toggles the `completed` flag on a single exercise within daily_log.exercises
+ * for the given date. Reads the current JSON, patches it, then writes back.
+ */
+export async function upsertExerciseCompleted(
+  date: string,
+  exerciseId: string,
+  value: boolean
+): Promise<void> {
+  const db = getDatabase();
+  const row = await db.getFirstAsync<{ exercises: string }>(
+    'SELECT exercises FROM daily_log WHERE date = ?',
+    [date]
+  );
+  const exercises = parseExercises(row?.exercises);
+  const updated = exercises.map((ex) =>
+    ex.id === exerciseId ? { ...ex, completed: value } : ex
+  );
   await db.runAsync(
-    `UPDATE daily_log SET ${field} = ? WHERE date = ?`,
-    [value ? 1 : 0, date]
+    'UPDATE daily_log SET exercises = ? WHERE date = ?',
+    [JSON.stringify(updated), date]
   );
 }
 
@@ -435,16 +375,15 @@ export async function upsertLogField(
 // Weekly Template CRUD
 // ─────────────────────────────────────────────
 
-/** Returns all 7 weekly template rows, ordered Mon→Sun. */
 export async function getWeeklyTemplate(): Promise<WeeklyTemplateDay[]> {
   const db = getDatabase();
-  // Order: Mon(1), Tue(2), Wed(3), Thu(4), Fri(5), Sat(6), Sun(0)
   const rows = await db.getAllAsync<{
     day_of_week: number;
     walking_task: string;
     hammer_task: string;
     is_rest_day: number;
     is_meal_prep_day: number;
+    exercises: string;
   }>(
     `SELECT * FROM weekly_template
      ORDER BY CASE day_of_week WHEN 0 THEN 7 ELSE day_of_week END ASC`
@@ -456,10 +395,11 @@ export async function getWeeklyTemplate(): Promise<WeeklyTemplateDay[]> {
     hammer_task: r.hammer_task,
     is_rest_day: r.is_rest_day === 1,
     is_meal_prep_day: r.is_meal_prep_day === 1,
+    exercises: parseExercises(r.exercises),
   }));
 }
 
-/** Updates the walking_task and hammer_task for a given day_of_week. */
+/** Updates the walking_task, hammer_task for a given day_of_week. */
 export async function updateTemplateDay(
   dayOfWeek: number,
   walkingTask: string,
@@ -472,11 +412,26 @@ export async function updateTemplateDay(
   );
 }
 
+/**
+ * Replaces the full exercise list for a given weekday in weekly_template.
+ * The UI calls this when the user adds, edits, or deletes exercises in the
+ * Template Editor.
+ */
+export async function updateTemplateExercises(
+  dayOfWeek: number,
+  exercises: Exercise[]
+): Promise<void> {
+  const db = getDatabase();
+  await db.runAsync(
+    'UPDATE weekly_template SET exercises = ? WHERE day_of_week = ?',
+    [JSON.stringify(exercises), dayOfWeek]
+  );
+}
+
 // ─────────────────────────────────────────────
 // App State helpers
 // ─────────────────────────────────────────────
 
-/** Returns the app start date stored in app_state. */
 export async function getStartDate(): Promise<string> {
   const db = getDatabase();
   const row = await db.getFirstAsync<{ value: string }>(
@@ -486,7 +441,6 @@ export async function getStartDate(): Promise<string> {
   return row?.value ?? toISODate();
 }
 
-/** Returns the progression cycle number for a given ISO date. */
 export async function getCycleForDate(dateISO: string): Promise<number> {
   const startISO = await getStartDate();
   const diff = daysBetween(startISO, dateISO);
@@ -506,6 +460,7 @@ function mapLogRow(row: {
   fasting_completed: number;
   is_rest_day: number;
   is_meal_prep_day: number;
+  exercises: string;
 }): DailyLogEntry {
   return {
     date: row.date,
@@ -516,5 +471,6 @@ function mapLogRow(row: {
     fasting_completed: row.fasting_completed === 1,
     is_rest_day: row.is_rest_day === 1,
     is_meal_prep_day: row.is_meal_prep_day === 1,
+    exercises: parseExercises(row.exercises),
   };
 }

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -6,10 +6,18 @@
  *   - weekly_template holds 7 base rows indexed by JavaScript day-of-week (0=Sun…6=Sat)
  *   - daily_log is the rolling tracker: always contains today–7 to today+7
  *   - syncRollingSchedule() must be called on every app launch
+ *
+ * Fixes applied:
+ *   - #34  Better error propagation (stack preserved, logged to console)
+ *   - #35  Multi-row INSERT replaced by versioned individual statements
+ *   - #36  _db singleton only assigned after full successful init; cleaned up on failure
+ *   - #37  SELECT moved outside withTransactionAsync to avoid SQLITE_BUSY on iOS
+ *   - #38  _db reset to null on failure so a hot-reload or retry can re-open cleanly
+ *   - #39  Versioned migration runner using schema_version table
  */
 
 import * as SQLite from 'expo-sqlite';
-import { ALL_MIGRATIONS } from './schema';
+import { CREATE_SCHEMA_VERSION_TABLE, MIGRATIONS } from './schema';
 
 // ─────────────────────────────────────────────
 // Constants
@@ -18,15 +26,16 @@ import { ALL_MIGRATIONS } from './schema';
 const DB_NAME = 'healthtracker.db';
 const START_DATE_KEY = 'app_start_date';
 
-// Weight added per 21-day progression cycle (kg)
+/** Weight added per 21-day progression cycle (kg) */
 const KG_PER_CYCLE = 5;
-// Number of days per progression cycle
+/** Number of days per progression cycle */
 const CYCLE_DAYS = 21;
-// Days to generate ahead of today
+/** Days to generate ahead of today */
 const DAYS_AHEAD = 7;
-// Days of history to retain (older than this are pruned)
+/** Days of history to retain (entries older than this are pruned) */
 const DAYS_HISTORY = 7;
 
+/** Module-level singleton. Only assigned after a fully successful init. */
 let _db: SQLite.SQLiteDatabase | null = null;
 
 // ─────────────────────────────────────────────
@@ -100,66 +109,50 @@ function buildHammerTask(
 }
 
 // ─────────────────────────────────────────────
-// Database Init
+// Versioned migration runner  (#39)
 // ─────────────────────────────────────────────
 
 /**
- * Opens the database, runs all migrations/seeds, records start date on first
- * launch, then syncs the rolling schedule.
- * Must be awaited before any other DB call.
+ * Creates the schema_version table if needed, then applies every migration
+ * that has not yet been recorded there. Each migration runs once and is
+ * immediately marked as applied, so re-running initDatabase() is safe.
  */
-export async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
-  if (_db) return _db;
+async function runMigrations(db: SQLite.SQLiteDatabase): Promise<void> {
+  // Ensure the version-tracking table exists first
+  await db.execAsync(CREATE_SCHEMA_VERSION_TABLE);
 
-  _db = await SQLite.openDatabaseAsync(DB_NAME);
-
-  // Enable WAL for better concurrent reads
-  await _db.execAsync('PRAGMA journal_mode = WAL;');
-
-  // Run all migrations (idempotent CREATE TABLE IF NOT EXISTS + INSERT OR IGNORE)
-  for (const statement of ALL_MIGRATIONS) {
-    await _db.execAsync(statement);
-  }
-
-  // Record start date on very first launch
-  const existing = await _db.getFirstAsync<{ value: string }>(
-    'SELECT value FROM app_state WHERE key = ?',
-    [START_DATE_KEY]
+  // Fetch already-applied versions
+  const appliedRows = await db.getAllAsync<{ version: number }>(
+    'SELECT version FROM schema_version ORDER BY version ASC'
   );
-  if (!existing) {
-    const today = toISODate();
-    await _db.runAsync(
-      'INSERT INTO app_state (key, value) VALUES (?, ?)',
-      [START_DATE_KEY, today]
+  const applied = new Set(appliedRows.map((r) => r.version));
+
+  // Apply each pending migration in order
+  for (const migration of MIGRATIONS) {
+    if (applied.has(migration.version)) continue;
+
+    console.log(`[DB] Applying migration v${migration.version}…`);
+    await db.execAsync(migration.sql);
+    await db.runAsync(
+      'INSERT INTO schema_version (version) VALUES (?)',
+      [migration.version]
     );
+    console.log(`[DB] Migration v${migration.version} applied ✓`);
   }
-
-  // Generate / prune the rolling window
-  await syncRollingSchedule();
-
-  return _db;
-}
-
-/** Returns the open DB instance. initDatabase() must have been called first. */
-export function getDatabase(): SQLite.SQLiteDatabase {
-  if (!_db) throw new Error('Database not initialised. Call initDatabase() first.');
-  return _db;
 }
 
 // ─────────────────────────────────────────────
-// Task 3 — Rolling Schedule Sync
+// Rolling schedule sync — internal impl  (#37)
 // ─────────────────────────────────────────────
 
 /**
- * Ensures the daily_log table always has entries from today up to today+7.
- * Any entry older than today-7 is pruned.
+ * Internal implementation that accepts an explicit db reference so it can be
+ * called safely during initDatabase() before _db is assigned.  (#36 / #37)
  *
- * Called automatically by initDatabase() and can be called manually on
- * app foregrounding.
+ * SELECTs are performed OUTSIDE the transaction to avoid SQLITE_BUSY on iOS
+ * with expo-sqlite v14+. Only write operations run inside the transaction.
  */
-export async function syncRollingSchedule(): Promise<void> {
-  const db = getDatabase();
-
+async function _syncRollingSchedule(db: SQLite.SQLiteDatabase): Promise<void> {
   // 1. Fetch app_start_date for progression maths
   const startRow = await db.getFirstAsync<{ value: string }>(
     'SELECT value FROM app_state WHERE key = ?',
@@ -181,54 +174,147 @@ export async function syncRollingSchedule(): Promise<void> {
     templateMap.set(row.day_of_week, row);
   }
 
-  // 3. Determine the dates that should exist: today … today+DAYS_AHEAD
+  // 3. Determine target dates: today … today+DAYS_AHEAD
   const today = new Date();
   today.setHours(0, 0, 0, 0);
+  const cutoffDate = addDays(today, -DAYS_HISTORY);
+  const cutoffISO = toISODate(cutoffDate);
 
+  // 4. Pre-fetch existing log dates OUTSIDE the transaction  (#37)
+  //    This avoids read calls inside withTransactionAsync which can cause
+  //    SQLITE_BUSY / "database is locked" on iOS (expo-sqlite v14+).
+  const existingRows = await db.getAllAsync<{ date: string }>(
+    'SELECT date FROM daily_log WHERE date >= ?',
+    [cutoffISO]
+  );
+  const existingDates = new Set(existingRows.map((r) => r.date));
+
+  // Build the list of inserts needed before entering the transaction
+  type InsertParams = [string, string, string, number, number];
+  const inserts: InsertParams[] = [];
+
+  for (let offset = 0; offset <= DAYS_AHEAD; offset++) {
+    const targetDate = addDays(today, offset);
+    const targetISO = toISODate(targetDate);
+
+    if (existingDates.has(targetISO)) continue;
+
+    const dow = targetDate.getDay(); // 0=Sun … 6=Sat
+    const template = templateMap.get(dow);
+    if (!template) continue; // No template row — shouldn't happen after seeding
+
+    const daysDiff = daysBetween(startDateISO, targetISO);
+    const hammerWithWeight = buildHammerTask(
+      template.hammer_task,
+      template.is_rest_day === 1,
+      daysDiff
+    );
+
+    inserts.push([
+      targetISO,
+      template.walking_task,
+      hammerWithWeight,
+      template.is_rest_day,
+      template.is_meal_prep_day,
+    ]);
+  }
+
+  // 5. Execute inserts + prune inside a single transaction (writes only)  (#37)
   await db.withTransactionAsync(async () => {
-    for (let offset = 0; offset <= DAYS_AHEAD; offset++) {
-      const targetDate = addDays(today, offset);
-      const targetISO = toISODate(targetDate);
-
-      // Skip if a log entry already exists for this date
-      const existing = await db.getFirstAsync<{ date: string }>(
-        'SELECT date FROM daily_log WHERE date = ?',
-        [targetISO]
-      );
-      if (existing) continue;
-
-      // Look up the template row for this weekday
-      const dow = targetDate.getDay(); // 0=Sun … 6=Sat
-      const template = templateMap.get(dow);
-      if (!template) continue; // No template row — skip (shouldn't happen)
-
-      // Calculate progression
-      const daysDiff = daysBetween(startDateISO, targetISO);
-      const hammerWithWeight = buildHammerTask(
-        template.hammer_task,
-        template.is_rest_day === 1,
-        daysDiff
-      );
-
-      // Insert the generated log entry (all checkboxes start unchecked)
+    for (const params of inserts) {
       await db.runAsync(
         `INSERT OR IGNORE INTO daily_log
            (date, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
          VALUES (?, ?, ?, ?, ?)`,
-        [
-          targetISO,
-          template.walking_task,
-          hammerWithWeight,
-          template.is_rest_day,
-          template.is_meal_prep_day,
-        ]
+        params
       );
     }
 
-    // 4. Prune entries older than today - DAYS_HISTORY
-    const cutoff = toISODate(addDays(today, -DAYS_HISTORY));
-    await db.runAsync('DELETE FROM daily_log WHERE date < ?', [cutoff]);
+    // Prune entries older than today - DAYS_HISTORY
+    await db.runAsync('DELETE FROM daily_log WHERE date < ?', [cutoffISO]);
   });
+}
+
+// ─────────────────────────────────────────────
+// Database Init  (#36 / #38)
+// ─────────────────────────────────────────────
+
+/**
+ * Opens the database, runs all versioned migrations, records the start date on
+ * first launch, then syncs the rolling schedule.
+ *
+ * The module-level `_db` singleton is only assigned after the full sequence
+ * succeeds. If anything throws, the connection is closed and `_db` remains
+ * null so that the next call (e.g. after a dev hot-reload) can try again
+ * cleanly.  (#36 / #38)
+ *
+ * Must be awaited before any other DB call.
+ */
+export async function initDatabase(): Promise<SQLite.SQLiteDatabase> {
+  if (_db) return _db;
+
+  console.log('[DB] Opening database…');
+  const db = await SQLite.openDatabaseAsync(DB_NAME);
+
+  try {
+    // Enable WAL for better concurrent reads
+    await db.execAsync('PRAGMA journal_mode = WAL;');
+
+    // Run versioned migrations (idempotent)  (#39)
+    await runMigrations(db);
+
+    // Record start date on very first launch
+    const existing = await db.getFirstAsync<{ value: string }>(
+      'SELECT value FROM app_state WHERE key = ?',
+      [START_DATE_KEY]
+    );
+    if (!existing) {
+      const today = toISODate();
+      console.log(`[DB] First launch — recording start date: ${today}`);
+      await db.runAsync(
+        'INSERT INTO app_state (key, value) VALUES (?, ?)',
+        [START_DATE_KEY, today]
+      );
+    }
+
+    // Generate / prune the rolling window
+    await _syncRollingSchedule(db);
+
+    // Only assign the singleton after full success  (#36)
+    _db = db;
+    console.log('[DB] Initialisation complete ✓');
+  } catch (err) {
+    // Clean up the connection so a retry (e.g. after Metro hot-reload) works  (#38)
+    console.error('[DB] Initialisation failed — closing connection:', err);
+    await db.closeAsync().catch((closeErr) =>
+      console.warn('[DB] Failed to close connection during cleanup:', closeErr)
+    );
+    // _db is deliberately NOT assigned — remains null for next call
+    throw err; // rethrow so App.tsx can display the real message
+  }
+
+  return _db!;
+}
+
+/** Returns the open DB instance. initDatabase() must have been called first. */
+export function getDatabase(): SQLite.SQLiteDatabase {
+  if (!_db) throw new Error('Database not initialised. Call initDatabase() first.');
+  return _db;
+}
+
+// ─────────────────────────────────────────────
+// Task 3 — Rolling Schedule Sync (public API)
+// ─────────────────────────────────────────────
+
+/**
+ * Ensures the daily_log table always has entries from today up to today+7.
+ * Any entry older than today-7 is pruned.
+ *
+ * Called automatically by initDatabase() and can be called manually on
+ * app foregrounding.
+ */
+export async function syncRollingSchedule(): Promise<void> {
+  return _syncRollingSchedule(getDatabase());
 }
 
 // ─────────────────────────────────────────────

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,14 +9,27 @@
  * Migration tracking:
  *   schema_version — records every applied migration version so that each
  *   statement runs exactly once, even across app updates.
+ *
+ * v11: ADD COLUMN exercises TEXT to weekly_template
+ * v12: ADD COLUMN exercises TEXT to daily_log
  */
+
+// ─── Exercise type (shared between DB layer and UI) ───────────────────────────
+
+export interface Exercise {
+  /** Stable per-exercise identifier — survives restarts. */
+  id: string;
+  name: string;
+  sets: string;
+  reps: string;
+  /** YouTube URL; empty string if no tutorial available. */
+  videoUrl: string;
+  /** Per-day completion state stored in daily_log.exercises. */
+  completed: boolean;
+}
 
 // ─── Bootstrap ────────────────────────────────────────────────────────────────
 
-/**
- * Created first, before anything else, so the migration runner can track
- * which statements have already been applied.
- */
 export const CREATE_SCHEMA_VERSION_TABLE = `
   CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER PRIMARY KEY NOT NULL
@@ -32,11 +45,6 @@ export const CREATE_APP_STATE_TABLE = `
   );
 `;
 
-/**
- * day_of_week follows JavaScript's Date.getDay():
- *   0 = Sunday, 1 = Monday, 2 = Tuesday, 3 = Wednesday,
- *   4 = Thursday, 5 = Friday, 6 = Saturday
- */
 export const CREATE_WEEKLY_TEMPLATE_TABLE = `
   CREATE TABLE IF NOT EXISTS weekly_template (
     day_of_week      INTEGER PRIMARY KEY NOT NULL,
@@ -60,73 +68,254 @@ export const CREATE_DAILY_LOG_TABLE = `
   );
 `;
 
-// ─── Seed Data ────────────────────────────────────────────────────────────────
-// Each weekday gets its own INSERT OR IGNORE statement (one row per statement).
-// This is compatible with every SQLite version, including those bundled by
-// older Android API levels that do not support multi-row VALUES clauses.
-// INSERT OR IGNORE ensures rows are inserted only once and are never
-// overwritten — the Template Editor uses UPDATE to modify them later.
+// ─── Column additions (v11 / v12) ─────────────────────────────────────────────
+
+export const ADD_EXERCISES_TO_WEEKLY_TEMPLATE = `
+  ALTER TABLE weekly_template ADD COLUMN exercises TEXT NOT NULL DEFAULT '[]';
+`;
+
+export const ADD_EXERCISES_TO_DAILY_LOG = `
+  ALTER TABLE daily_log ADD COLUMN exercises TEXT NOT NULL DEFAULT '[]';
+`;
+
+// ─── Exercise seed data ───────────────────────────────────────────────────────
+// Stable IDs use deterministic short strings so they never change between
+// migrations or reinstalls — the UI relies on these IDs for completion state.
+
+/** Monday — Upper Push/Pull */
+export const EXERCISES_MON: Exercise[] = [
+  {
+    id: 'mon-01', name: 'Chest Press', sets: '3', reps: '8-10',
+    videoUrl: 'https://www.youtube.com/watch?v=cgHlQLlYffk', completed: false,
+  },
+  {
+    id: 'mon-02', name: 'Lat Pulldown', sets: '3', reps: '8-10',
+    videoUrl: 'https://www.youtube.com/watch?v=TRC5LCYi6W0', completed: false,
+  },
+  {
+    id: 'mon-03', name: 'Seated Row', sets: '3', reps: '8-10',
+    videoUrl: 'https://www.youtube.com/watch?v=qvJK5l34WsY', completed: false,
+  },
+  {
+    id: 'mon-04', name: 'Butterfly', sets: '3', reps: '8-10',
+    videoUrl: 'https://www.youtube.com/watch?v=y5Z4V_cBDoE', completed: false,
+  },
+];
+
+/** Tuesday — Lower Body */
+export const EXERCISES_TUE: Exercise[] = [
+  {
+    id: 'tue-01', name: 'Smith Squats', sets: '4', reps: '10-12',
+    videoUrl: 'https://www.youtube.com/watch?v=KvpLvDF0kfA', completed: false,
+  },
+  {
+    id: 'tue-02', name: 'Reverse Lunges', sets: '4', reps: '10-12',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'tue-03', name: 'Leg Extension', sets: '4', reps: '10-12',
+    videoUrl: 'https://www.youtube.com/watch?v=MAbThtU8Sis', completed: false,
+  },
+  {
+    id: 'tue-04', name: 'Leg Curls', sets: '4', reps: '10-12',
+    videoUrl: 'https://www.youtube.com/watch?v=MAbThtU8Sis', completed: false,
+  },
+];
+
+/** Wednesday — Arms / Core (rest day) */
+export const EXERCISES_WED: Exercise[] = [
+  {
+    id: 'wed-01', name: 'Cable Bicep Curls', sets: '3', reps: '15',
+    videoUrl: 'https://www.youtube.com/watch?v=Z8CE9QVpNtM', completed: false,
+  },
+  {
+    id: 'wed-02', name: 'Tricep Pushdowns', sets: '3', reps: '15',
+    videoUrl: 'https://www.youtube.com/watch?v=Z8CE9QVpNtM', completed: false,
+  },
+  {
+    id: 'wed-03', name: 'Cable Crunches', sets: '3', reps: '15',
+    videoUrl: '', completed: false,
+  },
+];
+
+/** Thursday — Upper Heavy */
+export const EXERCISES_THU: Exercise[] = [
+  {
+    id: 'thu-01', name: 'Incline Press', sets: '4', reps: '6-8',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'thu-02', name: 'Pull-ups', sets: '4', reps: '6-8',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'thu-03', name: 'Upright Row', sets: '4', reps: '6-8',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'thu-04', name: 'Lateral Raise', sets: '4', reps: '6-8',
+    videoUrl: '', completed: false,
+  },
+];
+
+/** Friday — Lower Volume */
+export const EXERCISES_FRI: Exercise[] = [
+  {
+    id: 'fri-01', name: 'Cable RDLs', sets: '3', reps: '15-20',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'fri-02', name: 'Split Squats', sets: '3', reps: '15-20',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'fri-03', name: 'Leg Extension', sets: '3', reps: '15-20',
+    videoUrl: 'https://www.youtube.com/watch?v=MAbThtU8Sis', completed: false,
+  },
+  {
+    id: 'fri-04', name: 'Leg Curls', sets: '3', reps: '15-20',
+    videoUrl: 'https://www.youtube.com/watch?v=MAbThtU8Sis', completed: false,
+  },
+];
+
+/** Saturday — Accessories / Meal Prep */
+export const EXERCISES_SAT: Exercise[] = [
+  {
+    id: 'sat-01', name: 'Face Pulls', sets: '3', reps: '12-15',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'sat-02', name: 'Pull-throughs', sets: '3', reps: '12-15',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'sat-03', name: 'Calf Raises', sets: '3', reps: '12-15',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'sat-04', name: 'Core Twists', sets: '3', reps: '12-15',
+    videoUrl: '', completed: false,
+  },
+];
+
+/** Sunday — Recovery */
+export const EXERCISES_SUN: Exercise[] = [
+  {
+    id: 'sun-01', name: 'Light Cable Recovery', sets: '1', reps: 'Light',
+    videoUrl: '', completed: false,
+  },
+  {
+    id: 'sun-02', name: 'Deep Stretching', sets: '1', reps: '45 min',
+    videoUrl: '', completed: false,
+  },
+];
+
+// ─── Seed INSERTs (individual rows — compatible with all SQLite versions) ──────
 
 const SEED_MON = `
   INSERT OR IGNORE INTO weekly_template
-    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
   VALUES (1, 'Office Pad (10k-15k steps)',
              'Chest Press, Lat Pulldown, Seated Row, Butterfly (3 x 8-10)',
-             0, 0);
+             0, 0, '[]');
 `;
 
 const SEED_TUE = `
   INSERT OR IGNORE INTO weekly_template
-    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
   VALUES (2, 'Office Pad (10k-15k steps)',
              'Smith Squats, Reverse Lunges, Leg Ext, Leg Curls (4 x 10-12)',
-             0, 0);
+             0, 0, '[]');
 `;
 
 const SEED_WED = `
   INSERT OR IGNORE INTO weekly_template
-    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
   VALUES (3, 'Rest (No Walk)',
              'Cable Bicep Curls, Tricep Pushdowns, Cable Crunches (3 x 15)',
-             1, 0);
+             1, 0, '[]');
 `;
 
 const SEED_THU = `
   INSERT OR IGNORE INTO weekly_template
-    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
   VALUES (4, 'Office Pad (10k-15k steps)',
              'Incline Press, Pull-ups, Upright Row, Lateral Raise (4 x 6-8)',
-             0, 0);
+             0, 0, '[]');
 `;
 
 const SEED_FRI = `
   INSERT OR IGNORE INTO weekly_template
-    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
   VALUES (5, 'Office Pad (10k-15k steps)',
              'Cable RDLs, Split Squats, Leg Ext, Leg Curls (3 x 15-20)',
-             0, 0);
+             0, 0, '[]');
 `;
 
 const SEED_SAT = `
   INSERT OR IGNORE INTO weekly_template
-    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
   VALUES (6, 'Meal Prep Weekend (No Walk)',
              'Face Pulls, Pull-throughs, Calf Raises, Core Twists (3 x 12-15)',
-             0, 1);
+             0, 1, '[]');
 `;
 
 const SEED_SUN = `
   INSERT OR IGNORE INTO weekly_template
-    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day, exercises)
   VALUES (0, 'Buochs Marina Loop (6.99 km)',
              'Light Cable Recovery & 45min Deep Stretching',
-             1, 0);
+             1, 0, '[]');
+`;
+
+// ─── Exercise JSON seed UPDATEs (migration v13–v19) ───────────────────────────
+// Run AFTER the ALTER TABLE migrations so the column exists.
+// Uses UPDATE with WHERE day_of_week so they are safe to rerun (no-op if data matches).
+// These run as separate versioned migrations so they fire once on each device.
+
+export const SEED_EXERCISES_MON = `
+  UPDATE weekly_template
+  SET exercises = '${JSON.stringify(EXERCISES_MON)}'
+  WHERE day_of_week = 1 AND (exercises IS NULL OR exercises = '[]');
+`;
+
+export const SEED_EXERCISES_TUE = `
+  UPDATE weekly_template
+  SET exercises = '${JSON.stringify(EXERCISES_TUE)}'
+  WHERE day_of_week = 2 AND (exercises IS NULL OR exercises = '[]');
+`;
+
+export const SEED_EXERCISES_WED = `
+  UPDATE weekly_template
+  SET exercises = '${JSON.stringify(EXERCISES_WED)}'
+  WHERE day_of_week = 3 AND (exercises IS NULL OR exercises = '[]');
+`;
+
+export const SEED_EXERCISES_THU = `
+  UPDATE weekly_template
+  SET exercises = '${JSON.stringify(EXERCISES_THU)}'
+  WHERE day_of_week = 4 AND (exercises IS NULL OR exercises = '[]');
+`;
+
+export const SEED_EXERCISES_FRI = `
+  UPDATE weekly_template
+  SET exercises = '${JSON.stringify(EXERCISES_FRI)}'
+  WHERE day_of_week = 5 AND (exercises IS NULL OR exercises = '[]');
+`;
+
+export const SEED_EXERCISES_SAT = `
+  UPDATE weekly_template
+  SET exercises = '${JSON.stringify(EXERCISES_SAT)}'
+  WHERE day_of_week = 6 AND (exercises IS NULL OR exercises = '[]');
+`;
+
+export const SEED_EXERCISES_SUN = `
+  UPDATE weekly_template
+  SET exercises = '${JSON.stringify(EXERCISES_SUN)}'
+  WHERE day_of_week = 0 AND (exercises IS NULL OR exercises = '[]');
 `;
 
 // ─── Versioned Migration List ─────────────────────────────────────────────────
-// Each entry runs exactly once per device, tracked by `schema_version`.
-// To add future schema changes (e.g. ALTER TABLE) append a new entry with the
-// next version number — never edit or reorder existing entries.
 
 export interface Migration {
   version: number;
@@ -134,14 +323,27 @@ export interface Migration {
 }
 
 export const MIGRATIONS: Migration[] = [
-  { version: 1, sql: CREATE_APP_STATE_TABLE },
-  { version: 2, sql: CREATE_WEEKLY_TEMPLATE_TABLE },
-  { version: 3, sql: CREATE_DAILY_LOG_TABLE },
-  { version: 4, sql: SEED_MON },
-  { version: 5, sql: SEED_TUE },
-  { version: 6, sql: SEED_WED },
-  { version: 7, sql: SEED_THU },
-  { version: 8, sql: SEED_FRI },
-  { version: 9, sql: SEED_SAT },
+  // v1–v3: table creation
+  { version: 1,  sql: CREATE_APP_STATE_TABLE },
+  { version: 2,  sql: CREATE_WEEKLY_TEMPLATE_TABLE },
+  { version: 3,  sql: CREATE_DAILY_LOG_TABLE },
+  // v4–v10: per-row template seeds
+  { version: 4,  sql: SEED_MON },
+  { version: 5,  sql: SEED_TUE },
+  { version: 6,  sql: SEED_WED },
+  { version: 7,  sql: SEED_THU },
+  { version: 8,  sql: SEED_FRI },
+  { version: 9,  sql: SEED_SAT },
   { version: 10, sql: SEED_SUN },
+  // v11–v12: add exercises column
+  { version: 11, sql: ADD_EXERCISES_TO_WEEKLY_TEMPLATE },
+  { version: 12, sql: ADD_EXERCISES_TO_DAILY_LOG },
+  // v13–v19: populate exercises JSON for each weekday
+  { version: 13, sql: SEED_EXERCISES_MON },
+  { version: 14, sql: SEED_EXERCISES_TUE },
+  { version: 15, sql: SEED_EXERCISES_WED },
+  { version: 16, sql: SEED_EXERCISES_THU },
+  { version: 17, sql: SEED_EXERCISES_FRI },
+  { version: 18, sql: SEED_EXERCISES_SAT },
+  { version: 19, sql: SEED_EXERCISES_SUN },
 ];

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,11 +1,27 @@
 /**
  * SQLite schema for the 7-Day Rolling Window architecture.
  *
- * Three tables:
+ * Three domain tables:
  *   1. app_state       — key-value store (e.g., app_start_date)
  *   2. weekly_template — 7 base rows, one per weekday (seeded below)
  *   3. daily_log       — rolling tracker, date-keyed, pruned to ±7 days
+ *
+ * Migration tracking:
+ *   schema_version — records every applied migration version so that each
+ *   statement runs exactly once, even across app updates.
  */
+
+// ─── Bootstrap ────────────────────────────────────────────────────────────────
+
+/**
+ * Created first, before anything else, so the migration runner can track
+ * which statements have already been applied.
+ */
+export const CREATE_SCHEMA_VERSION_TABLE = `
+  CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY NOT NULL
+  );
+`;
 
 // ─── Table DDL ────────────────────────────────────────────────────────────────
 
@@ -23,83 +39,109 @@ export const CREATE_APP_STATE_TABLE = `
  */
 export const CREATE_WEEKLY_TEMPLATE_TABLE = `
   CREATE TABLE IF NOT EXISTS weekly_template (
-    day_of_week     INTEGER PRIMARY KEY NOT NULL,
-    walking_task    TEXT    NOT NULL,
-    hammer_task     TEXT    NOT NULL,
-    is_rest_day     INTEGER NOT NULL DEFAULT 0,
+    day_of_week      INTEGER PRIMARY KEY NOT NULL,
+    walking_task     TEXT    NOT NULL,
+    hammer_task      TEXT    NOT NULL,
+    is_rest_day      INTEGER NOT NULL DEFAULT 0,
     is_meal_prep_day INTEGER NOT NULL DEFAULT 0
   );
 `;
 
 export const CREATE_DAILY_LOG_TABLE = `
   CREATE TABLE IF NOT EXISTS daily_log (
-    date             TEXT    PRIMARY KEY NOT NULL,
-    walking_task     TEXT    NOT NULL,
-    hammer_task      TEXT    NOT NULL,
-    walk_completed   INTEGER NOT NULL DEFAULT 0,
-    hammer_completed INTEGER NOT NULL DEFAULT 0,
+    date              TEXT    PRIMARY KEY NOT NULL,
+    walking_task      TEXT    NOT NULL,
+    hammer_task       TEXT    NOT NULL,
+    walk_completed    INTEGER NOT NULL DEFAULT 0,
+    hammer_completed  INTEGER NOT NULL DEFAULT 0,
     fasting_completed INTEGER NOT NULL DEFAULT 0,
-    is_rest_day      INTEGER NOT NULL DEFAULT 0,
-    is_meal_prep_day INTEGER NOT NULL DEFAULT 0
+    is_rest_day       INTEGER NOT NULL DEFAULT 0,
+    is_meal_prep_day  INTEGER NOT NULL DEFAULT 0
   );
 `;
 
 // ─── Seed Data ────────────────────────────────────────────────────────────────
-// INSERT OR IGNORE ensures these rows are only inserted once and are never
-// overwritten by subsequent app launches. The user can edit them via the
-// Template Editor screen, which uses UPDATE directly.
+// Each weekday gets its own INSERT OR IGNORE statement (one row per statement).
+// This is compatible with every SQLite version, including those bundled by
+// older Android API levels that do not support multi-row VALUES clauses.
+// INSERT OR IGNORE ensures rows are inserted only once and are never
+// overwritten — the Template Editor uses UPDATE to modify them later.
 
-export const SEED_WEEKLY_TEMPLATE = `
+const SEED_MON = `
   INSERT OR IGNORE INTO weekly_template
     (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
-  VALUES
-    (
-      1,
-      'Office Pad (10k-15k steps)',
-      'Chest Press, Lat Pulldown, Seated Row, Butterfly (3 x 8-10)',
-      0, 0
-    ),
-    (
-      2,
-      'Office Pad (10k-15k steps)',
-      'Smith Squats, Reverse Lunges, Leg Ext, Leg Curls (4 x 10-12)',
-      0, 0
-    ),
-    (
-      3,
-      'Rest (No Walk)',
-      'Cable Bicep Curls, Tricep Pushdowns, Cable Crunches (3 x 15)',
-      1, 0
-    ),
-    (
-      4,
-      'Office Pad (10k-15k steps)',
-      'Incline Press, Pull-ups, Upright Row, Lateral Raise (4 x 6-8)',
-      0, 0
-    ),
-    (
-      5,
-      'Office Pad (10k-15k steps)',
-      'Cable RDLs, Split Squats, Leg Ext, Leg Curls (3 x 15-20)',
-      0, 0
-    ),
-    (
-      6,
-      'Meal Prep Weekend (No Walk)',
-      'Face Pulls, Pull-throughs, Calf Raises, Core Twists (3 x 12-15)',
-      0, 1
-    ),
-    (
-      0,
-      'Buochs Marina Loop (6.99 km)',
-      'Light Cable Recovery & 45min Deep Stretching',
-      1, 0
-    );
+  VALUES (1, 'Office Pad (10k-15k steps)',
+             'Chest Press, Lat Pulldown, Seated Row, Butterfly (3 x 8-10)',
+             0, 0);
 `;
 
-export const ALL_MIGRATIONS = [
-  CREATE_APP_STATE_TABLE,
-  CREATE_WEEKLY_TEMPLATE_TABLE,
-  CREATE_DAILY_LOG_TABLE,
-  SEED_WEEKLY_TEMPLATE,
+const SEED_TUE = `
+  INSERT OR IGNORE INTO weekly_template
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+  VALUES (2, 'Office Pad (10k-15k steps)',
+             'Smith Squats, Reverse Lunges, Leg Ext, Leg Curls (4 x 10-12)',
+             0, 0);
+`;
+
+const SEED_WED = `
+  INSERT OR IGNORE INTO weekly_template
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+  VALUES (3, 'Rest (No Walk)',
+             'Cable Bicep Curls, Tricep Pushdowns, Cable Crunches (3 x 15)',
+             1, 0);
+`;
+
+const SEED_THU = `
+  INSERT OR IGNORE INTO weekly_template
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+  VALUES (4, 'Office Pad (10k-15k steps)',
+             'Incline Press, Pull-ups, Upright Row, Lateral Raise (4 x 6-8)',
+             0, 0);
+`;
+
+const SEED_FRI = `
+  INSERT OR IGNORE INTO weekly_template
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+  VALUES (5, 'Office Pad (10k-15k steps)',
+             'Cable RDLs, Split Squats, Leg Ext, Leg Curls (3 x 15-20)',
+             0, 0);
+`;
+
+const SEED_SAT = `
+  INSERT OR IGNORE INTO weekly_template
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+  VALUES (6, 'Meal Prep Weekend (No Walk)',
+             'Face Pulls, Pull-throughs, Calf Raises, Core Twists (3 x 12-15)',
+             0, 1);
+`;
+
+const SEED_SUN = `
+  INSERT OR IGNORE INTO weekly_template
+    (day_of_week, walking_task, hammer_task, is_rest_day, is_meal_prep_day)
+  VALUES (0, 'Buochs Marina Loop (6.99 km)',
+             'Light Cable Recovery & 45min Deep Stretching',
+             1, 0);
+`;
+
+// ─── Versioned Migration List ─────────────────────────────────────────────────
+// Each entry runs exactly once per device, tracked by `schema_version`.
+// To add future schema changes (e.g. ALTER TABLE) append a new entry with the
+// next version number — never edit or reorder existing entries.
+
+export interface Migration {
+  version: number;
+  sql: string;
+}
+
+export const MIGRATIONS: Migration[] = [
+  { version: 1, sql: CREATE_APP_STATE_TABLE },
+  { version: 2, sql: CREATE_WEEKLY_TEMPLATE_TABLE },
+  { version: 3, sql: CREATE_DAILY_LOG_TABLE },
+  { version: 4, sql: SEED_MON },
+  { version: 5, sql: SEED_TUE },
+  { version: 6, sql: SEED_WED },
+  { version: 7, sql: SEED_THU },
+  { version: 8, sql: SEED_FRI },
+  { version: 9, sql: SEED_SAT },
+  { version: 10, sql: SEED_SUN },
 ];

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -6,12 +6,16 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
+  Linking,
+  Alert,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   DailyLogEntry,
+  Exercise,
   getLogByDate,
   upsertLogField,
+  upsertExerciseCompleted,
   syncRollingSchedule,
   toISODate,
 } from '../db/database';
@@ -66,6 +70,127 @@ function TaskCard({
   );
 }
 
+// ─── Exercise Row ─────────────────────────────────────────────────────────────
+
+function ExerciseRow({
+  exercise,
+  onToggle,
+}: {
+  exercise: Exercise;
+  onToggle: () => void;
+}) {
+  const handleWatch = async () => {
+    if (!exercise.videoUrl) return;
+    const supported = await Linking.canOpenURL(exercise.videoUrl);
+    if (supported) {
+      await Linking.openURL(exercise.videoUrl);
+    } else {
+      Alert.alert('Cannot open URL', exercise.videoUrl);
+    }
+  };
+
+  return (
+    <View style={[styles.exerciseRow, exercise.completed && styles.exerciseRowDone]}>
+      {/* Checkbox */}
+      <TouchableOpacity
+        style={[styles.exCheckbox, exercise.completed && styles.exCheckboxDone]}
+        onPress={onToggle}
+        activeOpacity={0.7}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        {exercise.completed && <Text style={styles.exCheckmark}>✓</Text>}
+      </TouchableOpacity>
+
+      {/* Name + sets/reps */}
+      <View style={styles.exInfo}>
+        <Text style={[styles.exName, exercise.completed && styles.exNameDone]}>
+          {exercise.name}
+        </Text>
+        <Text style={styles.exMeta}>
+          {exercise.sets} sets × {exercise.reps} reps
+        </Text>
+      </View>
+
+      {/* Watch Tutorial button */}
+      {exercise.videoUrl ? (
+        <TouchableOpacity
+          style={styles.watchBtn}
+          onPress={handleWatch}
+          activeOpacity={0.75}
+        >
+          <Text style={styles.watchBtnIcon}>▶</Text>
+          <Text style={styles.watchBtnLabel}>Watch</Text>
+        </TouchableOpacity>
+      ) : (
+        <View style={styles.watchBtnPlaceholder} />
+      )}
+    </View>
+  );
+}
+
+// ─── Hammer Section ───────────────────────────────────────────────────────────
+
+function HammerSection({
+  entry,
+  onExerciseToggle,
+  onSessionToggle,
+}: {
+  entry: DailyLogEntry;
+  onExerciseToggle: (id: string, value: boolean) => void;
+  onSessionToggle: () => void;
+}) {
+  const doneCount = entry.exercises.filter((e) => e.completed).length;
+  const total = entry.exercises.length;
+  const allDone = total > 0 && doneCount === total;
+
+  return (
+    <View style={styles.section}>
+      {/* Section header */}
+      <View style={[styles.hammerHeader, { borderLeftColor: Colors.secondary }]}>
+        <View style={styles.hammerHeaderLeft}>
+          <Text style={styles.taskIcon}>🏋️</Text>
+          <View>
+            <Text style={styles.taskTitle}>HAMMER MULTI-GYM</Text>
+            <Text style={styles.hammerSubtitle}>{entry.hammer_task}</Text>
+          </View>
+        </View>
+        {total > 0 && (
+          <View style={[styles.exProgressPill, allDone && styles.exProgressPillDone]}>
+            <Text style={[styles.exProgressText, allDone && styles.exProgressTextDone]}>
+              {doneCount}/{total}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* Exercise list */}
+      {entry.exercises.length > 0 ? (
+        <View style={styles.exerciseList}>
+          {entry.exercises.map((ex) => (
+            <ExerciseRow
+              key={ex.id}
+              exercise={ex}
+              onToggle={() => onExerciseToggle(ex.id, !ex.completed)}
+            />
+          ))}
+        </View>
+      ) : (
+        // Fallback for days with no exercise data yet
+        <Text style={styles.noExercisesHint}>
+          No individual exercises configured — use the Template Editor to add them.
+        </Text>
+      )}
+
+      {/* Session-level completion checkbox */}
+      <Checkbox
+        checked={entry.hammer_completed}
+        label="Mark full gym session complete"
+        onToggle={onSessionToggle}
+      />
+    </View>
+  );
+}
+
 // ─── Main Screen ──────────────────────────────────────────────────────────────
 
 export default function DashboardScreen() {
@@ -77,7 +202,6 @@ export default function DashboardScreen() {
   const loadToday = useCallback(async () => {
     setLoading(true);
     try {
-      // Re-sync in case days were missed (e.g., device clock advanced)
       await syncRollingSchedule();
       const data = await getLogByDate(today);
       setEntry(data);
@@ -97,15 +221,32 @@ export default function DashboardScreen() {
   ) => {
     if (!entry) return;
     const newValue = !entry[field];
-
-    // Optimistic UI update
     setEntry((prev) => prev ? { ...prev, [field]: newValue } : prev);
-
     try {
       await upsertLogField(today, field, newValue);
     } catch (err) {
       console.error('upsertLogField error', err);
-      loadToday(); // Revert on error
+      loadToday();
+    }
+  };
+
+  const handleExerciseToggle = async (exerciseId: string, value: boolean) => {
+    if (!entry) return;
+    // Optimistic update
+    setEntry((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        exercises: prev.exercises.map((ex) =>
+          ex.id === exerciseId ? { ...ex, completed: value } : ex
+        ),
+      };
+    });
+    try {
+      await upsertExerciseCompleted(today, exerciseId, value);
+    } catch (err) {
+      console.error('upsertExerciseCompleted error', err);
+      loadToday();
     }
   };
 
@@ -216,19 +357,11 @@ export default function DashboardScreen() {
         </View>
 
         {/* ── Hammer / Gym task ────────────────────────────────────────────── */}
-        <View style={styles.section}>
-          <TaskCard
-            icon="🏋️"
-            title="Hammer Multi-Gym"
-            description={entry.hammer_task}
-            accentColor={Colors.secondary}
-          />
-          <Checkbox
-            checked={entry.hammer_completed}
-            label="Gym session completed"
-            onToggle={() => handleToggle('hammer_completed')}
-          />
-        </View>
+        <HammerSection
+          entry={entry}
+          onExerciseToggle={handleExerciseToggle}
+          onSessionToggle={() => handleToggle('hammer_completed')}
+        />
 
         {/* ── Intermittent fasting ─────────────────────────────────────────── */}
         <View style={styles.section}>
@@ -416,5 +549,131 @@ const styles = StyleSheet.create({
   checkboxLabelChecked: {
     color: Colors.accent,
     textDecorationLine: 'line-through',
+  },
+
+  // Hammer section header
+  hammerHeader: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radius.md,
+    padding: Spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderLeftWidth: 3,
+    gap: Spacing.sm,
+  },
+  hammerHeaderLeft: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Spacing.md,
+    flex: 1,
+  },
+  hammerSubtitle: {
+    fontSize: Typography.sizes.sm,
+    color: Colors.textSecondary,
+    lineHeight: 18,
+    marginTop: 2,
+    flexShrink: 1,
+  },
+  exProgressPill: {
+    backgroundColor: Colors.border,
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    minWidth: 36,
+    alignItems: 'center',
+  },
+  exProgressPillDone: { backgroundColor: Colors.accent + '30' },
+  exProgressText: {
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    fontWeight: Typography.weights.bold,
+  },
+  exProgressTextDone: { color: Colors.accent },
+
+  // Exercise list
+  exerciseList: {
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radius.md,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+
+  // Exercise row
+  exerciseRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.sm + 2,
+    paddingHorizontal: Spacing.md,
+    gap: Spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  exerciseRowDone: { backgroundColor: Colors.accent + '08' },
+  exCheckbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 2,
+    borderColor: Colors.secondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  exCheckboxDone: {
+    backgroundColor: Colors.secondary,
+    borderColor: Colors.secondary,
+  },
+  exCheckmark: {
+    color: Colors.background,
+    fontSize: 12,
+    fontWeight: Typography.weights.bold,
+  },
+  exInfo: { flex: 1, gap: 1 },
+  exName: {
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+    fontWeight: Typography.weights.semibold,
+  },
+  exNameDone: {
+    color: Colors.textMuted,
+    textDecorationLine: 'line-through',
+  },
+  exMeta: {
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+  },
+
+  // Watch button
+  watchBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: Colors.secondary + '25',
+    borderRadius: Radius.sm,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 5,
+    borderWidth: 1,
+    borderColor: Colors.secondary + '60',
+  },
+  watchBtnIcon: {
+    color: Colors.secondary,
+    fontSize: 10,
+  },
+  watchBtnLabel: {
+    fontSize: Typography.sizes.xs,
+    color: Colors.secondary,
+    fontWeight: Typography.weights.semibold,
+  },
+  watchBtnPlaceholder: { width: 58 }, // same width as watchBtn to keep alignment
+
+  // No exercises hint
+  noExercisesHint: {
+    fontSize: Typography.sizes.sm,
+    color: Colors.textMuted,
+    fontStyle: 'italic',
+    textAlign: 'center',
+    paddingVertical: Spacing.md,
   },
 });

--- a/src/screens/TemplateEditorScreen.tsx
+++ b/src/screens/TemplateEditorScreen.tsx
@@ -10,43 +10,197 @@ import {
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Modal,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   WeeklyTemplateDay,
+  Exercise,
   getWeeklyTemplate,
   updateTemplateDay,
+  updateTemplateExercises,
 } from '../db/database';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
 
-// ─── Day label map ────────────────────────────────────────────────────────────
+// ─── Day label maps ───────────────────────────────────────────────────────────
 
 const DAY_LABELS: Record<number, string> = {
-  1: 'Monday',
-  2: 'Tuesday',
-  3: 'Wednesday',
-  4: 'Thursday',
-  5: 'Friday',
-  6: 'Saturday',
-  0: 'Sunday',
+  1: 'Monday', 2: 'Tuesday', 3: 'Wednesday', 4: 'Thursday',
+  5: 'Friday', 6: 'Saturday', 0: 'Sunday',
 };
 
 const DAY_SHORT: Record<number, string> = {
   1: 'MON', 2: 'TUE', 3: 'WED', 4: 'THU', 5: 'FRI', 6: 'SAT', 0: 'SUN',
 };
 
-// ─── Single editiable day card ────────────────────────────────────────────────
+// ─── Exercise Edit Modal ──────────────────────────────────────────────────────
+
+interface ExerciseModalProps {
+  visible: boolean;
+  initial: Exercise | null; // null = adding new
+  onSave: (ex: Exercise) => void;
+  onClose: () => void;
+}
+
+function ExerciseModal({ visible, initial, onSave, onClose }: ExerciseModalProps) {
+  const [name, setName] = useState('');
+  const [sets, setSets] = useState('3');
+  const [reps, setReps] = useState('');
+  const [videoUrl, setVideoUrl] = useState('');
+
+  // Sync form when the modal opens
+  useEffect(() => {
+    if (visible) {
+      setName(initial?.name ?? '');
+      setSets(initial?.sets ?? '3');
+      setReps(initial?.reps ?? '');
+      setVideoUrl(initial?.videoUrl ?? '');
+    }
+  }, [visible, initial]);
+
+  const handleSave = () => {
+    if (!name.trim()) {
+      Alert.alert('Validation', 'Exercise name cannot be empty.');
+      return;
+    }
+    const ex: Exercise = {
+      id: initial?.id ?? `ex-${Date.now()}`,
+      name: name.trim(),
+      sets: sets.trim() || '3',
+      reps: reps.trim(),
+      videoUrl: videoUrl.trim(),
+      completed: false,
+    };
+    onSave(ex);
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.modalOverlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={styles.modalSheet}>
+          <View style={styles.modalHandle} />
+          <Text style={styles.modalTitle}>
+            {initial ? 'Edit Exercise' : 'Add Exercise'}
+          </Text>
+
+          <View style={styles.modalFields}>
+            <View style={styles.fieldGroup}>
+              <Text style={styles.fieldLabel}>NAME</Text>
+              <TextInput
+                style={styles.input}
+                value={name}
+                onChangeText={setName}
+                placeholder="e.g. Chest Press"
+                placeholderTextColor={Colors.textMuted}
+                autoFocus
+              />
+            </View>
+
+            <View style={styles.fieldRow}>
+              <View style={[styles.fieldGroup, { flex: 1 }]}>
+                <Text style={styles.fieldLabel}>SETS</Text>
+                <TextInput
+                  style={styles.input}
+                  value={sets}
+                  onChangeText={setSets}
+                  keyboardType="numeric"
+                  placeholder="3"
+                  placeholderTextColor={Colors.textMuted}
+                />
+              </View>
+              <View style={[styles.fieldGroup, { flex: 2 }]}>
+                <Text style={styles.fieldLabel}>REPS / DURATION</Text>
+                <TextInput
+                  style={styles.input}
+                  value={reps}
+                  onChangeText={setReps}
+                  placeholder="e.g. 8-10 or 45 min"
+                  placeholderTextColor={Colors.textMuted}
+                />
+              </View>
+            </View>
+
+            <View style={styles.fieldGroup}>
+              <Text style={styles.fieldLabel}>YOUTUBE URL (optional)</Text>
+              <TextInput
+                style={styles.input}
+                value={videoUrl}
+                onChangeText={setVideoUrl}
+                placeholder="https://youtube.com/watch?v=…"
+                placeholderTextColor={Colors.textMuted}
+                autoCapitalize="none"
+                keyboardType="url"
+              />
+            </View>
+          </View>
+
+          <View style={styles.modalActions}>
+            <TouchableOpacity style={styles.cancelBtn} onPress={onClose}>
+              <Text style={styles.cancelBtnText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.saveBtn} onPress={handleSave}>
+              <Text style={styles.saveBtnText}>
+                {initial ? 'Save Changes' : 'Add Exercise'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+// ─── Single Exercises List Item ───────────────────────────────────────────────
+
+function ExerciseItem({
+  exercise,
+  onEdit,
+  onDelete,
+}: {
+  exercise: Exercise;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <View style={styles.exItem}>
+      <View style={styles.exItemInfo}>
+        <Text style={styles.exItemName}>{exercise.name}</Text>
+        <Text style={styles.exItemMeta}>
+          {exercise.sets}×{exercise.reps}
+          {exercise.videoUrl ? '  · 📹 Video' : ''}
+        </Text>
+      </View>
+      <TouchableOpacity style={styles.exEditBtn} onPress={onEdit}>
+        <Text style={styles.exEditBtnText}>✏️</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.exDeleteBtn} onPress={onDelete}>
+        <Text style={styles.exDeleteBtnText}>✕</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+// ─── Single editable day card ─────────────────────────────────────────────────
 
 interface TemplateCardProps {
   day: WeeklyTemplateDay;
   onSave: (dayOfWeek: number, walk: string, hammer: string) => Promise<void>;
+  onExercisesChange: (dayOfWeek: number, exercises: Exercise[]) => Promise<void>;
 }
 
-function TemplateCard({ day, onSave }: TemplateCardProps) {
+function TemplateCard({ day, onSave, onExercisesChange }: TemplateCardProps) {
   const [walk, setWalk] = useState(day.walking_task);
   const [hammer, setHammer] = useState(day.hammer_task);
+  const [exercises, setExercises] = useState<Exercise[]>(day.exercises);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+
+  // Exercise modal state
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingExercise, setEditingExercise] = useState<Exercise | null>(null);
 
   const isDirty = walk !== day.walking_task || hammer !== day.hammer_task;
 
@@ -67,6 +221,51 @@ function TemplateCard({ day, onSave }: TemplateCardProps) {
     }
   };
 
+  const openAddModal = () => {
+    setEditingExercise(null);
+    setModalVisible(true);
+  };
+
+  const openEditModal = (ex: Exercise) => {
+    setEditingExercise(ex);
+    setModalVisible(true);
+  };
+
+  const handleExerciseSave = async (ex: Exercise) => {
+    let updated: Exercise[];
+    if (editingExercise) {
+      updated = exercises.map((e) => (e.id === ex.id ? ex : e));
+    } else {
+      updated = [...exercises, ex];
+    }
+    setExercises(updated);
+    setModalVisible(false);
+    try {
+      await onExercisesChange(day.day_of_week, updated);
+    } catch (err: any) {
+      Alert.alert('Error', err.message ?? 'Failed to save exercises.');
+    }
+  };
+
+  const handleDeleteExercise = (id: string) => {
+    Alert.alert('Delete Exercise', 'Remove this exercise from the template?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          const updated = exercises.filter((e) => e.id !== id);
+          setExercises(updated);
+          try {
+            await onExercisesChange(day.day_of_week, updated);
+          } catch (err: any) {
+            Alert.alert('Error', err.message ?? 'Failed to delete exercise.');
+          }
+        },
+      },
+    ]);
+  };
+
   const accentColor = day.is_rest_day
     ? Colors.textMuted
     : day.is_meal_prep_day
@@ -85,12 +284,8 @@ function TemplateCard({ day, onSave }: TemplateCardProps) {
         <View style={styles.cardHeaderInfo}>
           <Text style={styles.dayLabel}>{DAY_LABELS[day.day_of_week]}</Text>
           <View style={styles.tagRow}>
-            {day.is_rest_day && (
-              <Text style={styles.tagRest}>💤 Rest Day</Text>
-            )}
-            {day.is_meal_prep_day && (
-              <Text style={styles.tagMealPrep}>🥗 Meal Prep</Text>
-            )}
+            {day.is_rest_day && <Text style={styles.tagRest}>💤 Rest Day</Text>}
+            {day.is_meal_prep_day && <Text style={styles.tagMealPrep}>🥗 Meal Prep</Text>}
           </View>
         </View>
       </View>
@@ -108,15 +303,15 @@ function TemplateCard({ day, onSave }: TemplateCardProps) {
         />
       </View>
 
-      {/* Hammer Task (base — no weight suffix shown here) */}
+      {/* Hammer Task label */}
       <View style={styles.fieldGroup}>
-        <Text style={styles.fieldLabel}>🏋️ HAMMER TASK (base)</Text>
+        <Text style={styles.fieldLabel}>🏋️ HAMMER TASK (base label)</Text>
         <TextInput
           style={styles.input}
           value={hammer}
           onChangeText={setHammer}
           multiline
-          placeholder="Enter hammer / gym task…"
+          placeholder="Enter hammer / gym task label…"
           placeholderTextColor={Colors.textMuted}
         />
         <Text style={styles.inputHint}>
@@ -125,7 +320,7 @@ function TemplateCard({ day, onSave }: TemplateCardProps) {
         </Text>
       </View>
 
-      {/* Save button */}
+      {/* Save button for walk/hammer label edits */}
       {isDirty && (
         <TouchableOpacity
           style={[styles.saveBtn, saving && styles.saveBtnDisabled]}
@@ -135,7 +330,7 @@ function TemplateCard({ day, onSave }: TemplateCardProps) {
           {saving ? (
             <ActivityIndicator size="small" color={Colors.background} />
           ) : (
-            <Text style={styles.saveBtnText}>Save changes</Text>
+            <Text style={styles.saveBtnText}>Save label changes</Text>
           )}
         </TouchableOpacity>
       )}
@@ -143,6 +338,39 @@ function TemplateCard({ day, onSave }: TemplateCardProps) {
       {saved && !isDirty && (
         <Text style={styles.savedConfirm}>✓ Saved — future days will use this template</Text>
       )}
+
+      {/* ── Exercises ────────────────────────────────────────────────── */}
+      <View style={styles.exSection}>
+        <View style={styles.exSectionHeader}>
+          <Text style={styles.fieldLabel}>💪 EXERCISES ({exercises.length})</Text>
+          <TouchableOpacity style={styles.addExBtn} onPress={openAddModal}>
+            <Text style={styles.addExBtnText}>+ Add</Text>
+          </TouchableOpacity>
+        </View>
+
+        {exercises.length === 0 ? (
+          <Text style={styles.noExHint}>No exercises yet. Tap + Add to create one.</Text>
+        ) : (
+          <View style={styles.exList}>
+            {exercises.map((ex) => (
+              <ExerciseItem
+                key={ex.id}
+                exercise={ex}
+                onEdit={() => openEditModal(ex)}
+                onDelete={() => handleDeleteExercise(ex.id)}
+              />
+            ))}
+          </View>
+        )}
+      </View>
+
+      {/* Exercise modal */}
+      <ExerciseModal
+        visible={modalVisible}
+        initial={editingExercise}
+        onSave={handleExerciseSave}
+        onClose={() => setModalVisible(false)}
+      />
     </View>
   );
 }
@@ -173,12 +401,23 @@ export default function TemplateEditorScreen() {
   const handleSave = useCallback(
     async (dayOfWeek: number, walk: string, hammer: string) => {
       await updateTemplateDay(dayOfWeek, walk, hammer);
-      // Refresh local state so unchanged cards reflect the updated value
       setTemplate((prev) =>
         prev.map((d) =>
           d.day_of_week === dayOfWeek
             ? { ...d, walking_task: walk, hammer_task: hammer }
             : d
+        )
+      );
+    },
+    []
+  );
+
+  const handleExercisesChange = useCallback(
+    async (dayOfWeek: number, exercises: Exercise[]) => {
+      await updateTemplateExercises(dayOfWeek, exercises);
+      setTemplate((prev) =>
+        prev.map((d) =>
+          d.day_of_week === dayOfWeek ? { ...d, exercises } : d
         )
       );
     },
@@ -213,7 +452,12 @@ export default function TemplateEditorScreen() {
         showsVerticalScrollIndicator={false}
       >
         {template.map((day) => (
-          <TemplateCard key={day.day_of_week} day={day} onSave={handleSave} />
+          <TemplateCard
+            key={day.day_of_week}
+            day={day}
+            onSave={handleSave}
+            onExercisesChange={handleExercisesChange}
+          />
         ))}
         <View style={{ height: 32 }} />
       </ScrollView>
@@ -225,12 +469,9 @@ export default function TemplateEditorScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: Colors.background },
-
   centred: {
-    flex: 1,
-    backgroundColor: Colors.background,
-    alignItems: 'center',
-    justifyContent: 'center',
+    flex: 1, backgroundColor: Colors.background,
+    alignItems: 'center', justifyContent: 'center',
   },
 
   // Header
@@ -255,10 +496,7 @@ const styles = StyleSheet.create({
 
   // Scroll
   scroll: { flex: 1 },
-  scrollContent: {
-    padding: Spacing.lg,
-    gap: Spacing.md,
-  },
+  scrollContent: { padding: Spacing.lg, gap: Spacing.md },
 
   // Card
   card: {
@@ -275,11 +513,9 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   dayBadge: {
-    width: 48,
-    height: 48,
+    width: 48, height: 48,
     borderRadius: Radius.sm,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: 'center', justifyContent: 'center',
   },
   dayBadgeText: {
     fontSize: Typography.sizes.xs,
@@ -304,8 +540,9 @@ const styles = StyleSheet.create({
     fontWeight: Typography.weights.medium,
   },
 
-  // Field
+  // Fields
   fieldGroup: { gap: 6 },
+  fieldRow: { flexDirection: 'row', gap: Spacing.sm },
   fieldLabel: {
     fontSize: Typography.sizes.xs,
     color: Colors.textMuted,
@@ -323,7 +560,7 @@ const styles = StyleSheet.create({
     color: Colors.textPrimary,
     fontSize: Typography.sizes.sm,
     lineHeight: 20,
-    minHeight: 52,
+    minHeight: 42,
     textAlignVertical: 'top',
   },
   inputHint: {
@@ -352,5 +589,122 @@ const styles = StyleSheet.create({
     fontSize: Typography.sizes.xs,
     textAlign: 'center',
     fontWeight: Typography.weights.medium,
+  },
+
+  // Exercise section
+  exSection: { gap: Spacing.sm, marginTop: 4 },
+  exSectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  addExBtn: {
+    backgroundColor: Colors.secondary + '25',
+    borderRadius: Radius.sm,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: 5,
+    borderWidth: 1,
+    borderColor: Colors.secondary + '60',
+  },
+  addExBtnText: {
+    color: Colors.secondary,
+    fontSize: Typography.sizes.xs,
+    fontWeight: Typography.weights.bold,
+  },
+  noExHint: {
+    fontSize: Typography.sizes.sm,
+    color: Colors.textMuted,
+    fontStyle: 'italic',
+    textAlign: 'center',
+    paddingVertical: Spacing.sm,
+  },
+  exList: {
+    backgroundColor: Colors.surface,
+    borderRadius: Radius.sm,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+
+  // Exercise item
+  exItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    gap: Spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  exItemInfo: { flex: 1, gap: 1 },
+  exItemName: {
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+    fontWeight: Typography.weights.semibold,
+  },
+  exItemMeta: {
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+  },
+  exEditBtn: {
+    width: 30, height: 30, alignItems: 'center', justifyContent: 'center',
+  },
+  exEditBtnText: { fontSize: 16 },
+  exDeleteBtn: {
+    width: 30, height: 30, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: Colors.danger + '18', borderRadius: Radius.sm,
+  },
+  exDeleteBtnText: {
+    fontSize: Typography.sizes.sm,
+    color: Colors.danger,
+    fontWeight: Typography.weights.bold,
+  },
+
+  // Exercise modal
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.75)',
+    justifyContent: 'flex-end',
+  },
+  modalSheet: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.md,
+    paddingBottom: 32,
+    gap: Spacing.md,
+  },
+  modalHandle: {
+    width: 40, height: 4,
+    backgroundColor: Colors.border,
+    borderRadius: 2,
+    alignSelf: 'center',
+    marginBottom: Spacing.sm,
+  },
+  modalTitle: {
+    fontSize: Typography.sizes.lg,
+    color: Colors.textPrimary,
+    fontWeight: Typography.weights.bold,
+  },
+  modalFields: { gap: Spacing.md },
+  modalActions: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: 4,
+  },
+  cancelBtn: {
+    flex: 1,
+    backgroundColor: Colors.surfaceElevated,
+    borderRadius: Radius.md,
+    paddingVertical: Spacing.md,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  cancelBtnText: {
+    color: Colors.textSecondary,
+    fontWeight: Typography.weights.semibold,
+    fontSize: Typography.sizes.sm,
   },
 });


### PR DESCRIPTION
Closes #40

## Summary
Implements individual exercise tracking with per-exercise checkboxes and embedded YouTube tutorial links.

## Changes

### `src/db/schema.ts`
- Added `Exercise` interface (id, name, sets, reps, videoUrl, completed)
- Migrations v11/v12: `ALTER TABLE` to add `exercises TEXT` column to `weekly_template` and `daily_log`
- Migrations v13–v19: seed each weekday's exercise JSON with real YouTube URLs for Mon/Tue/Wed exercises

### `src/db/database.ts`
- `WeeklyTemplateDay` and `DailyLogEntry` interfaces now include `exercises: Exercise[]`
- `parseExercises()` helper — null-safe JSON parser
- `upsertExerciseCompleted(date, exerciseId, value)` — patches a single exercise in the JSON array
- `updateTemplateExercises(dayOfWeek, exercises)` — replaces full exercise list for a weekday
- `syncRollingSchedule` copies template exercises to new daily_log rows (reset to `completed: false`)

### `src/screens/DashboardScreen.tsx`
- `HammerSection` component: renders exercise list with progress pill
- `ExerciseRow`: checkbox + name/sets/reps + ▶ Watch button via `Linking.openURL`
- Optimistic updates for individual exercise toggles
- Session-level checkbox remains for marking the whole gym session done

### `src/screens/TemplateEditorScreen.tsx`
- `ExerciseModal`: bottom-sheet form for adding/editing exercises (name, sets, reps, YouTube URL)
- `ExerciseItem`: list row with edit ✏️ and delete ✕ buttons per exercise
- `TemplateCard` now includes full exercises CRUD UI below the walking/hammer label fields

## Type check
`npx tsc --noEmit` passes with **0 errors**.