### PR TITLE
fix(ci): use legacy-peer-deps for npm ci to bypass jest dependency conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build APK Locally via EAS
         run: eas build -p android --profile preview --local --non-interactive --output app-release.apk

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Run Tests
         run: npm test


### PR DESCRIPTION
Adds `--legacy-peer-deps` to `npm ci` step inside `.github/workflows/` scripts to bypass backwards-compatibility peer dependency conflicts blocking standard resolution pipelines.