### PR TITLE
ci: configure EAS project ID for automated APK compilation checks

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,6 +28,12 @@
     },
     "plugins": [
       "expo-sqlite"
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "24cb496b-6efd-4d9b-a425-c3d44e571db2"
+      }
+    },
+    "owner": "sgnaegi"
   }
 }


### PR DESCRIPTION
Configures the `expo.extra.eas.projectId` internally inside `app.json` alongside initializing standard SDK mappings so `eas build --local` no longer crashes when executed non-interactively on the GitHub Actions runner environment.