### PR TITLE
ci: add android package name to app config for non-interactive eas builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
       "supportsTablet": true
     },
     "android": {
+      "package": "com.sgnaegi.healthtracker",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"


### PR DESCRIPTION
Defines `expo.android.package` string mapping required by EAS to synthesize the underlying Gradle application package configurations whenever run in a non-interactive CI flow.