### PR TITLE
ci: add global .npmrc for legacy peer deps in eas builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Introduces `.npmrc` containing `legacy-peer-deps=true`.

Context:
EAS CLI `eas build --local` initiates an internal `npm ci` without pulling the customized arguments we attached strictly to standard GitHub actions in earlier patches, rendering the pipeline susceptible to the exact same dependency strictness errors it was previously throwing under direct `npm ci`. A global `.npmrc` guarantees that whenever NPM compiles dependencies (even beneath abstraction plugins like EAS local plugins), it defaults to utilizing legacy peer dependencies.