### PR TITLE
fix: resolve TurboModule crash — downgrade reanimated to 3.16.7, remove worklets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react": "19.1.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
-        "react-native-reanimated": "~4.1.1",
+        "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0"
       },
@@ -31,7 +31,6 @@
         "@types/react": "~19.1.0",
         "jest": "^30.3.0",
         "jest-expo": "^55.0.16",
-        "react-native-worklets": "^0.8.1",
         "react-test-renderer": "^19.2.5",
         "typescript": "~5.9.2"
       }
@@ -1352,7 +1351,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -16556,18 +16554,27 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
-      "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
+      "version": "3.16.7",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.16.7.tgz",
+      "integrity": "sha512-qoUUQOwE1pHlmQ9cXTJ2MX9FQ9eHllopCLiWOkDkp6CER95ZWeXhJCP4cSm6AD4jigL5jHcZf/SkWrg8ttZUsw==",
       "license": "MIT",
       "dependencies": {
-        "react-native-is-edge-to-edge": "^1.2.1",
-        "semver": "^7.7.2"
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0",
+        "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "0.78 - 0.82",
-        "react-native-worklets": "0.5 - 0.8"
+        "react-native": "*"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -16593,32 +16600,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-worklets": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.1.tgz",
-      "integrity": "sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
-        "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
-        "react": "*",
-        "react-native": "0.81 - 0.85"
       }
     },
     "node_modules/react-native/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-reanimated": "~4.1.1",
+    "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0"
   },
@@ -36,7 +36,6 @@
     "@types/react": "~19.1.0",
     "jest": "^30.3.0",
     "jest-expo": "^55.0.16",
-    "react-native-worklets": "^0.8.1",
     "react-test-renderer": "^19.2.5",
     "typescript": "~5.9.2"
   },


### PR DESCRIPTION
## Problem

Scanning the QR code and opening the app on a physical Android device caused an immediate red-screen crash:

```
[runtime not ready]: Error: Exception in HostFunction:
TurboModule method "installTurboModule" called with 1 arguments
(expected argument count: 0).
```

## Root Cause

`react-native-reanimated ~4.1.1` (resolved to 4.1.7) introduced `react-native-worklets` as a required peer dependency. The `installTurboModule` TurboModule in `react-native-worklets@0.8.1` passes **1 argument** to the host function, but React Native 0.81.5 with `newArchEnabled: true` strictly enforces the **0-argument** signature from the original TurboModule spec.

Additionally, `react-native-worklets` was incorrectly placed in `devDependencies` — native TurboModules must be in `dependencies`.

## Fix

1. **Downgraded** `react-native-reanimated` from `~4.1.1` to `~3.16.1` (resolves to `3.16.7`) — the version recommended by Expo SDK 54's compatibility matrix
2. **Removed** `react-native-worklets` from `devDependencies` entirely — reanimated 3.x does not use this as a separate package

## Issues Closed
- Closes #219
- Closes #220
- Closes #221

## Related
- See #222 for the follow-up CI improvement (add `expo install --check` gate)