### PR TITLE
Redesign · theme-tokens: apply Verdure calm-wellness palette

### DIFF
--- a/design/verdure/DESIGN.md
+++ b/design/verdure/DESIGN.md
@@ -1,0 +1,64 @@
+# Design System: Verdure — Calm Wellness
+
+## 1. North star
+HealthTracker treats a 90-day program as a calm, sustainable wellness practice rather than a hardcore grind. The mood is a quiet morning kitchen: warm linen, soft botanical greens, natural light. Soft serif headlines and a rounded sans body give it a gentle, premium feel. Restraint over intensity — generous whitespace, no harsh lines, no neon.
+
+## 2. Color tokens
+Warm, muted, low-saturation. Sage is the lead/brand accent; clay warms anything food-related; sky is for rest/recovery; gold marks streaks and highlights. The canvas is a warm linen, never pure white or black.
+
+| Token | Hex | Use |
+|---|---|---|
+| `canvas` | `#F3EFE7` | App background (warm linen) |
+| `canvas2` | `#ECE6DA` | Recessed tracks, "missed" states |
+| `surface` | `#FBF9F4` | Cards, rows, nav bar |
+| `ink` | `#2C352E` | Primary text (deep pine, not black) |
+| `ink2` | `#5E665E` | Secondary text |
+| `mute` | `#98A096` | Labels, hints, qty |
+| `sage` | `#7C9A85` | Primary accent / fills |
+| `sage-d` (pine) | `#4E6B58` | Text on light, hero fills, emphasis |
+| `sage-t` | `#E6ECE2` | Sage tint (chips, tracks, icon chips) |
+| `clay` | `#C98A6B` | Food / meals / calories accent |
+| `clay-d` | `#9A5E42` | Text on clay tint |
+| `clay-t` | `#F3E6DB` | Clay tint |
+| `sky` | `#8FAABF` | Rest / recovery / fasting accent |
+| `sky-d` | `#516675` | Text on sky tint |
+| `sky-t` | `#E4EBF0` | Sky tint |
+| `gold` | `#C9A86A` | Streaks, partial states |
+| `gold-d` | `#8A7434` | Text on gold tint |
+| `gold-t` | `#F1E8D4` | Gold tint |
+| `line` | `rgba(44,53,46,.08)` | Hairline borders |
+| `line2` | `rgba(44,53,46,.15)` | Stronger borders, empty checkbox |
+
+Rule: text on a colored tint always uses the deep shade of that same family (e.g. clay text on clay-t), never gray or black.
+
+## 3. Typography
+Two families. **Fraunces** (soft serif) for display — screen titles, big numbers (day count, weight, timers), recipe titles. **Plus Jakarta Sans** for everything else — body, rows, labels, nav.
+
+- Display: Fraunces 600, tight tracking (-1 to -2%). Big numbers carry the personality.
+- Title: Jakarta 600, 13–15px.
+- Body: Jakarta 500, 12–13px, line-height ~1.45.
+- Micro-label: Jakarta 700, 10px, uppercase, +0.12em tracking, `mute` color.
+
+## 4. Shape, depth & spacing
+- Radii: cards 20–24px, rows/inputs 14–18px, icon chips 12–13px, pills 999px. Soft and rounded throughout.
+- Depth via tone, not hard shadows. Cards = `surface` on `canvas`. Floating device/CTA shadows are soft and low-opacity only.
+- No 1px dividers between list items where avoidable — use spacing or a hairline `line`.
+- Min 16px screen padding.
+
+## 5. Components
+- **Icon chip + row**: rounded tinted square icon (accent family) + title/subtitle + trailing state (check, count pill, or chevron). The core list primitive across Today, Cooking, Plan.
+- **Checkbox**: 24px circle; empty = `line2` ring; done = solid `sage` with white check; completed labels go `mute` + strikethrough.
+- **Hero block**: deep `sage-d` panel, white text, used for the day-count card and the active cooking timer. The one place with a strong fill.
+- **Progress ring / bar**: sage fill on `canvas2`/tint track; rounded caps.
+- **Buttons**: primary = solid `sage`, white text, radius 13; ghost = `surface` + `line2` border, `sage-d` text.
+- **Bottom tab bar**: 5 tabs (Today, Recipes, Plan, Shop, Stats) on `surface`; active tab `sage-d`. Outline icons only.
+- **Charts**: flat. Weight = sage line + soft sage-t area fill, last point a `sage-d` dot. Consistency = rounded dot grid (sage / gold / canvas2). Macros = flat donut (sage / clay / sky).
+
+## 6. Iconography
+Outline icons only (Tabler set in the mockups; map to a React Native icon set such as `@expo/vector-icons` Tabler/Feather on build). Light 1.5–2px stroke to match the type weight. No emoji in the UI.
+
+## 7. Screens covered
+Today (dashboard), Recipes, Recipe detail, Meal plan, Cooking tasks, Shopping list, Analytics. See `code.html` in this folder for the full visual board.
+
+## 8. Mapping to code
+These tokens are intended to replace `src/theme/tokens.ts`. Swap the dark palette for the values in §2, add a `fontFamily` for Fraunces + Plus Jakarta Sans (via `expo-font`), and widen the `Radius` scale (cards 20–24). Components above map 1:1 onto the existing screen structure, so the overhaul is mostly a token + component-styling pass rather than a re-architecture.

--- a/design/verdure/OVERHAUL_PLAN.md
+++ b/design/verdure/OVERHAUL_PLAN.md
@@ -1,0 +1,49 @@
+# Verdure UI overhaul — execution plan
+
+Handoff plan for executing the calm-wellness ("Verdure") redesign in Claude Code with the GitHub MCP. Pair this with `DESIGN.md` (the design system) and `code.html` (the visual board) in this folder.
+
+## Goal
+Replace the old dark fitness UI with the Verdure calm-wellness system across all main screens, shipped as small, reviewable PRs — one (or more) per screen — each attributed to NevinJulian.
+
+## Workflow conventions
+- **One issue per unit**, titled `Redesign · <unit>`.
+- **One branch per unit**, off `main`, named `redesign/<unit>` (e.g. `redesign/today`).
+- **Granular commits** — small, logical, Conventional Commits style (`feat(theme):`, `style(today):`, `docs(design):`). Never one giant commit.
+- **One PR per unit**, base `main`, body ends with `Closes #<issue>`.
+- **Verification gate (must pass before merge):** `npm run typecheck` (exit 0) **and** `npm test` (jest, all green). Both are green on `main` today, so any failure is introduced by the change.
+- **Merge straight into `main`** once green (auto-merge on green was approved). Pause after Unit 1 for review.
+- **Line endings:** the repo is LF in git; keep new/edited files LF. (Windows checkouts show CRLF locally — that's just the working copy, harmless.)
+
+## Suggested two-agent split
+- **coding agent** — creates the issue + `redesign/<unit>` branch, implements, commits granularly, opens the PR. Does not merge.
+- **testing agent** — runs `npm run typecheck` + `npm test`, comments the result on the PR, merges only if both pass.
+
+## Status
+- ✅ Design system locked: `design/verdure/DESIGN.md` + `code.html` (board). Already on disk in this repo.
+- ✅ **Unit 1 implemented locally:** `src/theme/tokens.ts` is already rewritten to the Verdure palette/radii/type slots (all existing token keys preserved, so screens recolour automatically). Verified: `npm run typecheck` ✅ and `npm test` ✅. It just needs committing → PR → merge.
+- ⬜ Units 2–10 pending (below).
+
+## Units
+
+| # | Unit | Branch | Scope / files |
+|---|------|--------|---------------|
+| 1 | Design tokens | `redesign/theme-tokens` | `src/theme/tokens.ts` (done locally) + add `design/verdure/` board. Keep all token keys; values → Verdure; soften `Radius`; add `display`/`body` type slots + extended colour tokens. |
+| 2 | Fonts | `redesign/fonts` | Load Fraunces (display) + Plus Jakarta Sans (body) via `expo-font`; set `Typography.display`/`body`. Adds deps — keep typecheck/jest green. |
+| 3 | Shared UI kit | `redesign/ui-kit` | New reusable components in `src/components` (Card, Row, IconChip, Pill, ProgressBar, Button, ScreenHeader) per `DESIGN.md` §5. |
+| 4 | Today (Dashboard) | `redesign/today` | `src/screens/DashboardScreen.tsx` — hero day card + ring, focus task rows, today's meals, weight, bottom tabs. |
+| 5 | Recipes | `redesign/recipes` | `src/screens/RecipesScreen.tsx` — search, filter chips, recipe card grid. |
+| 6 | Recipe detail | `redesign/recipe-detail` | `src/screens/RecipeDetailScreen.tsx` — hero, stat row, ingredients, method, action buttons. |
+| 7 | Meal plan | `redesign/meal-plan` | `src/screens/MealPrepScreen.tsx` — day selector, prep-day banner, meal cards, daily total. |
+| 8 | Cooking tasks | `redesign/cooking-tasks` | `src/screens/CookingTasksScreen.tsx` — progress, active timer card, task checklist with time chips. |
+| 9 | Shopping list | `redesign/shopping-list` | `src/screens/ShoppingListScreen.tsx` — progress, category groups, items with qty + check states. |
+| 10 | Analytics | `redesign/analytics` | `src/screens/AnalyticsDashboardScreen.tsx` — metric cards, weight trend, consistency grid, macros. |
+
+> Also restyle `OverviewScreen`, `TemplateEditorScreen`, `BioForceModal`, and `AppNavigator` (tab bar) to match — fold into the relevant unit or add follow-up units.
+
+## After the UI: the code refactor (separate track)
+Originally requested alongside the UI work — schedule as its own issues/branches once the redesign lands:
+- Replace the hardcoded `src/data/recipes.ts` with a real recipe API/source.
+- General refactor of the "very bad / hardcoded" functions surfaced during the screen work.
+
+## Sequencing
+Do units in order; each branch is cut from `main` **after** the previous PR merges, so changes stack cleanly. Units 4–10 depend on 1–3 (tokens, fonts, UI kit).

--- a/design/verdure/PROJECT_BRIEF.md
+++ b/design/verdure/PROJECT_BRIEF.md
@@ -1,0 +1,62 @@
+# HealthTracker — Verdure redesign: project & workflow brief
+
+The single "start here" document for executing the UI overhaul in Claude Code. Read this together with `CLAUDE.md` (repo architecture), `design/verdure/DESIGN.md` (design system), `design/verdure/code.html` (visual board of all 7 screens), and `design/verdure/OVERHAUL_PLAN.md` (detailed unit table).
+
+---
+
+## 1. The project
+HealthTracker is an **Expo / React Native** app (SDK 54, RN 0.81, React 19, TypeScript strict, New Architecture on). All data is **on-device in SQLite** via `expo-sqlite` — no backend, no remote API. It's a 90-day health program with these main screens: **Today** (dashboard: walking, gym, fasting, meals, weight), **Recipes** + **Recipe detail**, **Meal plan**, **Cooking tasks**, **Shopping list**, and **Analytics**.
+
+Architecture lives in `CLAUDE.md` — the short version: `src/db/database.ts` is the data-access spine (all queries + shared types), schema/migrations are append-only in `src/db/schema.ts`, navigation is a right-side drawer, and **`src/theme/tokens.ts` is the single source of truth for all colours, spacing, type, and radii** — screens must style through those tokens, never raw hex.
+
+Commands: `npm install --legacy-peer-deps`, `npm run typecheck` (`tsc --noEmit` — the only static check), `npm test` (jest).
+
+## 2. The redesign — "Verdure"
+A calm-wellness visual overhaul replacing the old dark fitness UI. Warm linen canvas, **sage** as the lead accent, **clay** for the food side, **sky** blue for rest, **gold** for streaks; soft serif (Fraunces) for display, rounded sans (Plus Jakarta Sans) for UI. Full system in `DESIGN.md`; every screen is mocked in `code.html`.
+
+## 3. GitHub workflow
+- **One issue per unit**, titled `Redesign · <unit>`.
+- **One branch per unit** off `main`, named `redesign/<unit>` (e.g. `redesign/today`).
+- **Granular commits**, Conventional Commits style (`feat(theme):`, `style(today):`, `docs(design):`). Never one giant commit.
+- **One PR per unit**, base `main`, body ends with `Closes #<issue>`.
+- **Merge straight into `main`** once green (auto-merge on green is approved; pause after Unit 1 for review).
+- Everything attributed to **NevinJulian** via the GitHub MCP.
+- Keep files **LF** (the repo is LF in git; Windows shows CRLF locally — harmless).
+
+## 4. Agent workflow
+Two project subagents in `.claude/agents/` drive each unit:
+- **coding** (`coding.md`, Sonnet) — creates the issue + `redesign/<unit>` branch, implements via the theme tokens, commits in small steps, opens the PR. **Never merges.**
+- **testing** (`testing.md`, Haiku) — runs `npm run typecheck` + `npm test`, comments the result on the PR, and **merges only if both pass**. Reports failures back for the coding agent to fix.
+
+Loop per unit: `coding` → PR → `testing` → merge (or bounce back) → next unit. Units are sequential — branch each from the updated `main` after the previous merges.
+
+## 5. Verification gate (must pass before merge)
+`npm run typecheck` exits 0 **and** `npm test` is all-green. Both are green on `main` today, so any failure is introduced by the change. (A full native/EAS build is out of scope for the gate.)
+
+## 6. Current status
+- ✅ Design system + visual board locked (`DESIGN.md`, `code.html`).
+- ✅ **Unit 1 already implemented locally:** `src/theme/tokens.ts` is rewritten to the Verdure palette/radii/type slots (all existing token keys preserved → screens recolour automatically). Verified locally: `npm run typecheck` ✅, `npm test` ✅. It just needs committing → PR → merge.
+- ✅ Redesign docs + agent files are on disk (this folder + `.claude/agents/`), uncommitted.
+- ⬜ Units 2–10 pending.
+
+## 7. Unit roadmap
+Full scope/files in `OVERHAUL_PLAN.md`. In order:
+
+1. **theme-tokens** — `src/theme/tokens.ts` (done locally) + the `design/verdure/` board & docs.
+2. **fonts** — load Fraunces + Plus Jakarta Sans via `expo-font`; wire `Typography.display`/`body`.
+3. **ui-kit** — shared components (Card, Row, IconChip, Pill, ProgressBar, Button, ScreenHeader).
+4. **today** — `DashboardScreen.tsx`.
+5. **recipes** — `RecipesScreen.tsx`.
+6. **recipe-detail** — `RecipeDetailScreen.tsx`.
+7. **meal-plan** — `MealPrepScreen.tsx`.
+8. **cooking-tasks** — `CookingTasksScreen.tsx`.
+9. **shopping-list** — `ShoppingListScreen.tsx`.
+10. **analytics** — `AnalyticsDashboardScreen.tsx`.
+
+(Also restyle `OverviewScreen`, `TemplateEditorScreen`, `BioForceModal`, and the drawer/tab bar in `AppNavigator` — fold into the nearest unit or add follow-ups.)
+
+## 8. After the UI — code refactor (separate track)
+Once the redesign lands, schedule as its own issues/branches: replace the hardcoded `src/data/recipes.ts` with a real recipe API/source, and clean up the other hardcoded/poorly-implemented functions surfaced during the screen work.
+
+## 9. How to run it
+Do one unit at a time with the two agents (Section 4). Start at Unit 1 — since the code is already done and green, it's just commit → PR → merge. Review the first merged PR, then continue unit by unit.

--- a/design/verdure/agents/coding.md
+++ b/design/verdure/agents/coding.md
@@ -1,0 +1,31 @@
+---
+name: coding
+description: Implements one unit of the Verdure UI redesign for the healthtracker app. Use when asked to build, restyle, or implement a screen or theme change. Creates the GitHub issue and branch, edits the React Native code, commits in small steps, and opens a PR — never merges.
+model: sonnet
+---
+
+You are the coding agent for the "Verdure" calm-wellness UI overhaul of the healthtracker React Native / Expo (TypeScript) app.
+
+Read these first, every time:
+- `design/verdure/DESIGN.md` — the design system (palette, typography, components).
+- `design/verdure/OVERHAUL_PLAN.md` — the unit list, branch names, commit conventions, and the verification gate.
+- `CLAUDE.md` — repo architecture, commands, and gotchas.
+
+**Tooling — important:** Use plain `git` for branches, commits, and pushes. Use the **GitHub MCP** for issues, pull requests, and merges — **never the `gh` CLI**.
+
+For the unit you are given, do exactly this and then stop:
+
+1. Create a GitHub issue via the GitHub MCP — title `Redesign · <unit>`, body summarising the scope. Note the issue number.
+2. Create the branch off `main` with git: `git checkout -b redesign/<unit>`.
+3. Implement the change in the relevant screen/component. Style ONLY through the theme tokens in `src/theme/tokens.ts` (Colors, Spacing, Radius, Typography) — never raw hex or magic numbers. Match `DESIGN.md`.
+4. Run `npm run typecheck` and `npm test`. Fix anything you broke until BOTH pass.
+5. Commit in small, logical steps with **git** using Conventional Commits (e.g. `style(today): …`, `feat(theme): …`). Never one giant commit, then `git push` to the branch.
+6. Open a PR **via the GitHub MCP** (base `main`, head `redesign/<unit>`) whose body ends with `Closes #<issue>`.
+7. Do NOT merge — hand off to the testing agent.
+
+Constraints:
+- Keep the change scoped to the single unit; don't touch unrelated files.
+- Preserve all exported token keys and the database/query patterns described in `CLAUDE.md`.
+- Migrations are append-only — never edit existing ones.
+
+When done, report: the issue number, branch name, PR number + URL, the commits you made, and the typecheck/test results.

--- a/design/verdure/agents/testing.md
+++ b/design/verdure/agents/testing.md
@@ -1,0 +1,23 @@
+---
+name: testing
+description: Verifies a redesign PR builds and passes tests, then merges it if green. Use after the coding agent opens a PR, or whenever asked to test and merge a branch for the healthtracker app.
+model: haiku
+---
+
+You are the testing agent for the healthtracker app. You verify and merge — you do NOT write feature code.
+
+**Tooling — important:** use git for any local checkout; use the **GitHub MCP** (never the `gh` CLI) for PR comments and merges.
+
+Given a branch or PR:
+
+1. Make sure the branch's changes are present locally (check out the branch if needed).
+2. Run `npm run typecheck` — it must exit 0.
+3. Run `npm test` — all Jest suites must pass.
+4. Post the result as a comment on the PR via the GitHub MCP: pass/fail plus the key output lines.
+5. If BOTH checks pass: merge the PR into `main` via the GitHub MCP, then confirm the merge succeeded and the linked issue closed.
+6. If EITHER check fails: do NOT merge. Report exactly what failed — the failing file or test name and the error message — so the coding agent can fix it.
+
+Rules:
+- Never modify source files beyond what is strictly needed to run the checks.
+- Both gates are green on `main` today, so any failure was introduced by the branch.
+- Keep your report concise: typecheck result, test result, merge status.

--- a/design/verdure/code.html
+++ b/design/verdure/code.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>HealthTracker — Verdure design board</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@3/dist/tabler-icons.min.css">
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap');
+:root{
+--canvas:#F3EFE7;--canvas2:#ECE6DA;--surface:#FBF9F4;--pure:#fff;
+--ink:#2C352E;--ink2:#5E665E;--mute:#98A096;
+--sage:#7C9A85;--sage-d:#4E6B58;--sage-t:#E6ECE2;
+--clay:#C98A6B;--clay-d:#9A5E42;--clay-t:#F3E6DB;
+--sky:#8FAABF;--sky-d:#516675;--sky-t:#E4EBF0;
+--gold:#C9A86A;--gold-d:#8A7434;--gold-t:#F1E8D4;
+--line:rgba(44,53,46,.08);--line2:rgba(44,53,46,.15);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:#E8E2D6;font-family:'Plus Jakarta Sans',system-ui,sans-serif;color:var(--ink);-webkit-font-smoothing:antialiased;padding:34px 18px 56px}
+.board{max-width:1000px;margin:0 auto}
+.sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)}
+
+/* system strip */
+.sys{display:flex;flex-wrap:wrap;gap:26px;align-items:center;justify-content:space-between;background:var(--surface);border:1px solid var(--line);border-radius:24px;padding:22px 26px;margin-bottom:38px}
+.sysL .ey{font-size:11px;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:var(--sage-d)}
+.sysL h1{font-family:'Fraunces';font-weight:600;font-size:34px;letter-spacing:-.02em;line-height:1.05;margin:4px 0 2px}
+.sysL p{font-size:13px;color:var(--ink2);max-width:330px;line-height:1.5}
+.sw{display:flex;gap:10px;flex-wrap:wrap}
+.swatch{text-align:center}
+.swatch i{display:block;width:46px;height:46px;border-radius:14px;border:1px solid var(--line)}
+.swatch span{display:block;font-size:9.5px;color:var(--mute);font-weight:600;margin-top:5px;letter-spacing:.02em}
+.spec{font-family:'Fraunces';font-size:28px;color:var(--ink);line-height:1}
+.spec small{display:block;font-family:'Plus Jakarta Sans';font-size:11px;color:var(--mute);font-weight:600;letter-spacing:.04em;margin-top:6px}
+
+/* gallery */
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,300px));gap:30px 26px;justify-content:center}
+.frame{display:flex;flex-direction:column;align-items:center;gap:12px}
+.cap{font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--ink2)}
+
+.phone{width:300px;height:646px;background:var(--canvas);border:1px solid var(--line2);border-radius:38px;overflow:hidden;display:flex;flex-direction:column;box-shadow:0 24px 54px -26px rgba(44,53,46,.5)}
+.sb{display:flex;justify-content:space-between;align-items:center;padding:13px 24px 2px;font-size:12px;font-weight:700;color:var(--ink);flex:none}
+.sb .r i{margin-left:6px;font-size:15px}
+.body{flex:1;overflow:hidden;padding:8px 16px 4px}
+.tab{flex:none;display:flex;justify-content:space-around;align-items:center;padding:9px 6px 15px;background:var(--surface);border-top:1px solid var(--line)}
+.tab a{display:flex;flex-direction:column;align-items:center;gap:3px;font-size:9px;font-weight:600;color:var(--mute);text-decoration:none;letter-spacing:.02em}
+.tab a i{font-size:21px}
+.tab a.on{color:var(--sage-d)}
+
+/* generic */
+.eyebrow{font-size:10px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--mute)}
+.htitle{font-family:'Fraunces';font-weight:600;color:var(--ink);font-size:25px;line-height:1.04;letter-spacing:-.01em}
+.htitle.sm{font-size:21px}
+.scrhead{display:flex;justify-content:space-between;align-items:flex-end;padding:6px 2px 14px}
+.avatar{width:38px;height:38px;border-radius:50%;background:var(--sage-t);color:var(--sage-d);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14px}
+.iconbtn{width:38px;height:38px;border-radius:12px;background:var(--surface);border:1px solid var(--line);color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:19px}
+.card{background:var(--surface);border:1px solid var(--line);border-radius:20px;padding:14px}
+.row{display:flex;align-items:center;gap:11px;background:var(--surface);border:1px solid var(--line);border-radius:18px;padding:11px 12px;margin-bottom:9px}
+.ic{width:38px;height:38px;border-radius:13px;display:flex;align-items:center;justify-content:center;font-size:19px;flex:none}
+.ic-sage{background:var(--sage-t);color:var(--sage-d)}
+.ic-clay{background:var(--clay-t);color:var(--clay-d)}
+.ic-sky{background:var(--sky-t);color:var(--sky-d)}
+.ic-gold{background:var(--gold-t);color:var(--gold-d)}
+.rc{flex:1;min-width:0}
+.rt{font-size:13px;font-weight:600;color:var(--ink);line-height:1.2}
+.rs{font-size:10.5px;color:var(--ink2);margin-top:2px;font-weight:500}
+.chk{width:24px;height:24px;border-radius:50%;border:1.6px solid var(--line2);display:flex;align-items:center;justify-content:center;color:#fff;font-size:13px;flex:none}
+.chk.on{background:var(--sage);border-color:var(--sage)}
+.chk.empty{color:transparent}
+.cnt{font-size:11px;font-weight:700;color:var(--clay-d);background:var(--clay-t);padding:4px 10px;border-radius:999px;flex:none}
+
+/* dashboard hero */
+.hero{background:var(--sage-d);border-radius:24px;padding:17px 18px;display:flex;justify-content:space-between;align-items:center;margin-bottom:13px}
+.hero .he{font-size:10px;font-weight:700;letter-spacing:.16em;text-transform:uppercase;color:rgba(255,255,255,.62)}
+.hero .hn{font-family:'Fraunces';font-weight:600;color:#fff;font-size:42px;line-height:1;margin-top:3px}
+.hero .hn span{font-size:19px;color:rgba(255,255,255,.6)}
+.hero .hsub{font-size:11px;color:rgba(255,255,255,.78);margin-top:5px;font-weight:500}
+.ring{position:relative;width:74px;height:74px;flex:none}
+.ring .rl{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;color:#fff}
+.ring .rl b{font-family:'Fraunces';font-size:18px;font-weight:600;line-height:1}
+.ring .rl em{font-style:normal;font-size:8px;letter-spacing:.1em;text-transform:uppercase;color:rgba(255,255,255,.65);margin-top:2px}
+.sectlbl{font-size:10px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--mute);margin:14px 2px 9px;display:flex;justify-content:space-between;align-items:center}
+.sectlbl a{color:var(--sage-d);text-decoration:none;font-size:9.5px}
+
+/* meals strip */
+.meal{display:flex;align-items:center;gap:10px;padding:9px 4px}
+.meal+.meal{border-top:1px solid var(--line)}
+.mname{flex:1;font-size:12.5px;font-weight:600;color:var(--ink)}
+.mkcal{font-size:10.5px;color:var(--ink2);font-weight:600}
+
+/* weight */
+.weight{display:flex;align-items:center;gap:12px}
+.weight .wv{font-family:'Fraunces';font-size:30px;font-weight:600;color:var(--ink);line-height:1}
+.weight .wv span{font-size:14px;color:var(--mute)}
+.trend{font-size:10.5px;font-weight:700;color:var(--sage-d);background:var(--sage-t);padding:3px 8px;border-radius:999px;display:inline-flex;align-items:center;gap:3px}
+.btn{border:none;border-radius:13px;font-family:inherit;font-weight:700;font-size:13px;padding:11px 14px;background:var(--sage);color:#fff;display:flex;align-items:center;justify-content:center;gap:7px;cursor:pointer}
+.btn.ghost{background:var(--surface);color:var(--sage-d);border:1px solid var(--line2)}
+.btn.sm{padding:9px 16px;font-size:12px;border-radius:11px}
+
+/* search + chips */
+.search{display:flex;align-items:center;gap:9px;background:var(--surface);border:1px solid var(--line);border-radius:14px;padding:11px 13px;color:var(--mute);font-size:13px;font-weight:500;margin-bottom:12px}
+.chips{display:flex;gap:7px;overflow:hidden;margin-bottom:13px}
+.chip{font-size:11px;font-weight:600;color:var(--ink2);background:var(--surface);border:1px solid var(--line);border-radius:999px;padding:6px 13px;white-space:nowrap;flex:none}
+.chip.on{background:var(--sage);color:#fff;border-color:var(--sage)}
+
+/* recipe grid */
+.rg{display:grid;grid-template-columns:1fr 1fr;gap:11px}
+.rcard{background:var(--surface);border:1px solid var(--line);border-radius:18px;overflow:hidden}
+.rcImg{height:66px;display:flex;align-items:center;justify-content:center;font-size:28px}
+.rcB{padding:9px 10px 11px}
+.rcT{font-size:12px;font-weight:600;color:var(--ink);line-height:1.22}
+.rcM{font-size:10px;color:var(--clay-d);font-weight:700;margin-top:5px}
+.rcTime{font-size:9.5px;color:var(--mute);font-weight:600;margin-top:3px;display:flex;align-items:center;gap:3px}
+
+/* recipe detail */
+.hero2{height:158px;border-radius:0;margin:-8px -16px 0;display:flex;align-items:flex-start;justify-content:space-between;padding:14px 16px;position:relative;overflow:hidden}
+.hero2 .big{position:absolute;right:-6px;bottom:-18px;font-size:120px;opacity:.32}
+.rbtn{width:34px;height:34px;border-radius:50%;background:rgba(255,255,255,.82);color:var(--ink);display:flex;align-items:center;justify-content:center;font-size:18px;z-index:1}
+.stats4{display:flex;gap:7px;margin:14px 0 13px}
+.stat{flex:1;background:var(--surface);border:1px solid var(--line);border-radius:14px;padding:9px 4px;text-align:center}
+.stat b{font-family:'Fraunces';font-size:17px;font-weight:600;color:var(--ink);display:block;line-height:1}
+.stat span{font-size:8.5px;color:var(--mute);font-weight:700;letter-spacing:.08em;text-transform:uppercase;display:block;margin-top:4px}
+.ing{display:flex;align-items:center;gap:9px;font-size:12px;color:var(--ink);padding:6px 2px;font-weight:500}
+.ing .d{width:6px;height:6px;border-radius:50%;background:var(--sage);flex:none}
+.step{display:flex;gap:10px;padding:6px 2px}
+.step b{width:20px;height:20px;border-radius:50%;background:var(--sage-t);color:var(--sage-d);font-size:11px;font-weight:700;display:flex;align-items:center;justify-content:center;flex:none}
+.step p{font-size:11.5px;color:var(--ink2);line-height:1.45;font-weight:500}
+
+/* meal prep day selector */
+.days{display:flex;gap:6px;margin-bottom:14px}
+.day{flex:1;text-align:center;padding:9px 0;border-radius:14px;background:var(--surface);border:1px solid var(--line);position:relative}
+.day b{font-size:13px;font-weight:700;color:var(--ink);display:block;font-family:'Fraunces'}
+.day span{font-size:8.5px;color:var(--mute);font-weight:600;display:block;margin-top:1px}
+.day.on{background:var(--sage-d);border-color:var(--sage-d)}
+.day.on b,.day.on span{color:#fff}
+.day .dot{position:absolute;top:5px;right:6px;width:5px;height:5px;border-radius:50%;background:var(--clay)}
+.banner{display:flex;align-items:center;gap:10px;background:var(--clay-t);border-radius:16px;padding:11px 13px;margin-bottom:12px}
+.banner .bt{font-size:12px;font-weight:700;color:var(--clay-d)}
+.banner .bs{font-size:10px;color:var(--clay-d);opacity:.8;font-weight:500}
+.mealcard{display:flex;align-items:center;gap:11px;background:var(--surface);border:1px solid var(--line);border-radius:16px;padding:10px 11px;margin-bottom:9px}
+.mealcard .mc1{flex:1}
+.mealcard .me{font-size:9px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--mute)}
+.mealcard .mr{font-size:12.5px;font-weight:600;color:var(--ink);margin-top:2px}
+
+/* progress bar */
+.pbar{height:7px;background:var(--canvas2);border-radius:999px;overflow:hidden}
+.pbar i{display:block;height:100%;background:var(--sage);border-radius:999px}
+.plabel{display:flex;justify-content:space-between;font-size:10.5px;font-weight:600;color:var(--ink2);margin-bottom:7px}
+
+/* cooking active */
+.active{background:var(--sage-d);border-radius:20px;padding:15px;color:#fff;margin-bottom:13px}
+.active .ae{font-size:9px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:rgba(255,255,255,.6)}
+.active .an{font-size:15px;font-weight:700;margin-top:4px}
+.active .timer{font-family:'Fraunces';font-size:34px;font-weight:600;margin-top:8px;display:flex;align-items:center;gap:8px}
+.tchip{font-size:9.5px;font-weight:700;color:var(--ink2);background:var(--canvas2);padding:3px 8px;border-radius:999px;flex:none}
+
+/* shopping */
+.cathead{font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--mute);margin:13px 2px 7px;display:flex;align-items:center;gap:6px}
+.item{display:flex;align-items:center;gap:11px;padding:8px 2px}
+.item+.item{border-top:1px solid var(--line)}
+.iname{flex:1;font-size:12.5px;font-weight:500;color:var(--ink)}
+.iname.done{color:var(--mute);text-decoration:line-through}
+.qty{font-size:10.5px;color:var(--mute);font-weight:600}
+
+/* analytics */
+.metrics{display:flex;gap:8px;margin-bottom:13px}
+.metric{flex:1;background:var(--surface);border:1px solid var(--line);border-radius:16px;padding:11px 10px}
+.metric b{font-family:'Fraunces';font-size:21px;font-weight:600;color:var(--ink);display:block;line-height:1}
+.metric .ml{font-size:8.5px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;color:var(--mute);margin-bottom:6px}
+.metric .mt{font-size:9px;font-weight:700;color:var(--sage-d);margin-top:4px}
+.ctitle{font-size:11px;font-weight:700;color:var(--ink);margin-bottom:11px;display:flex;justify-content:space-between;align-items:center}
+.dotgrid{display:grid;grid-template-columns:repeat(7,1fr);gap:6px}
+.dotgrid i{aspect-ratio:1;border-radius:6px;background:var(--sage)}
+.dotgrid i.p{background:var(--gold)}
+.dotgrid i.n{background:var(--canvas2)}
+.legend{display:flex;gap:13px;margin-top:11px;flex-wrap:wrap}
+.legend span{font-size:10px;font-weight:600;color:var(--ink2);display:flex;align-items:center;gap:5px}
+.legend i{width:9px;height:9px;border-radius:3px}
+</style>
+</head>
+<body>
+<h2 class="sr-only">Verdure: a calm-wellness redesign of the HealthTracker app, shown across seven mobile screens with a soft sage, clay and linen palette.</h2>
+<div class="board">
+
+  <div class="sys">
+    <div class="sysL">
+      <div class="ey">Verdure · calm wellness</div>
+      <h1>HealthTracker, reimagined</h1>
+      <p>Soft botanical tones, generous space and a gentle serif — wellness over hard-edged fitness. Sage leads, clay warms the food, blue rests.</p>
+    </div>
+    <div class="sw">
+      <div class="swatch"><i style="background:#F3EFE7"></i><span>Linen</span></div>
+      <div class="swatch"><i style="background:#7C9A85"></i><span>Sage</span></div>
+      <div class="swatch"><i style="background:#4E6B58"></i><span>Pine</span></div>
+      <div class="swatch"><i style="background:#C98A6B"></i><span>Clay</span></div>
+      <div class="swatch"><i style="background:#8FAABF"></i><span>Sky</span></div>
+      <div class="swatch"><i style="background:#C9A86A"></i><span>Gold</span></div>
+    </div>
+    <div class="spec">Aa<small>Fraunces · Jakarta Sans</small></div>
+  </div>
+
+  <div class="grid">
+
+    <!-- 1 DASHBOARD -->
+    <div class="frame">
+      <div class="phone">
+        <div class="sb"><span>8:42</span><span class="r"><i class="ti ti-wifi"></i><i class="ti ti-battery-3"></i></span></div>
+        <div class="body">
+          <div class="scrhead">
+            <div><div class="eyebrow">Monday · 8 June</div><div class="htitle" style="margin-top:3px">Good morning,<br>Nevin</div></div>
+            <div class="avatar">N</div>
+          </div>
+          <div class="hero">
+            <div>
+              <div class="he">Day</div>
+              <div class="hn">45<span>/90</span></div>
+              <div class="hsub">Halfway to your goal</div>
+            </div>
+            <div class="ring">
+              <svg width="74" height="74" viewBox="0 0 74 74"><circle cx="37" cy="37" r="31" fill="none" stroke="rgba(255,255,255,.22)" stroke-width="7"/><circle cx="37" cy="37" r="31" fill="none" stroke="#fff" stroke-width="7" stroke-linecap="round" stroke-dasharray="194.8" stroke-dashoffset="64.9" transform="rotate(-90 37 37)"/></svg>
+              <div class="rl"><b>2/3</b><em>tasks</em></div>
+            </div>
+          </div>
+          <div class="sectlbl">Today's focus</div>
+          <div class="row"><span class="ic ic-sage"><i class="ti ti-walk"></i></span><div class="rc"><div class="rt">Morning walk</div><div class="rs">6,000 steps · 45 min</div></div><span class="chk on"><i class="ti ti-check"></i></span></div>
+          <div class="row"><span class="ic ic-clay"><i class="ti ti-barbell"></i></span><div class="rc"><div class="rt">Hammer multi-gym</div><div class="rs">Push day · 4 of 6 done</div></div><span class="cnt">4/6</span></div>
+          <div class="row"><span class="ic ic-sky"><i class="ti ti-hourglass"></i></span><div class="rc"><div class="rt">Intermittent fasting</div><div class="rs">16:8 · window 12–8pm</div></div><span class="chk empty"></span></div>
+          <div class="sectlbl">Today's meals <a href="#">See plan</a></div>
+          <div class="card" style="padding:6px 13px">
+            <div class="meal"><span class="ic ic-sage" style="width:30px;height:30px;font-size:15px;border-radius:10px"><i class="ti ti-bowl"></i></span><span class="mname">Greek yogurt bowl</span><span class="mkcal">320</span></div>
+            <div class="meal"><span class="ic ic-clay" style="width:30px;height:30px;font-size:15px;border-radius:10px"><i class="ti ti-salad"></i></span><span class="mname">Chicken & quinoa</span><span class="mkcal">540</span></div>
+            <div class="meal"><span class="ic ic-sky" style="width:30px;height:30px;font-size:15px;border-radius:10px"><i class="ti ti-fish"></i></span><span class="mname">Salmon & greens</span><span class="mkcal">610</span></div>
+          </div>
+        </div>
+        <div class="tab"><a class="on"><i class="ti ti-home"></i>Today</a><a><i class="ti ti-book"></i>Recipes</a><a><i class="ti ti-calendar"></i>Plan</a><a><i class="ti ti-shopping-cart"></i>Shop</a><a><i class="ti ti-activity"></i>Stats</a></div>
+      </div>
+      <div class="cap">Today</div>
+    </div>
+
+    <!-- 2 RECIPES -->
+    <div class="frame">
+      <div class="phone">
+        <div class="sb"><span>8:42</span><span class="r"><i class="ti ti-wifi"></i><i class="ti ti-battery-3"></i></span></div>
+        <div class="body">
+          <div class="scrhead"><div><div class="eyebrow">42 saved</div><div class="htitle" style="margin-top:3px">Recipes</div></div><span class="iconbtn"><i class="ti ti-plus"></i></span></div>
+          <div class="search"><i class="ti ti-search"></i>Search recipes & ingredients</div>
+          <div class="chips"><span class="chip on">All</span><span class="chip">High-protein</span><span class="chip">Low-carb</span><span class="chip">Quick</span></div>
+          <div class="rg">
+            <div class="rcard"><div class="rcImg ic-clay"><i class="ti ti-fish"></i></div><div class="rcB"><div class="rcT">Grilled salmon & greens</div><div class="rcM">610 kcal · 42g protein</div><div class="rcTime"><i class="ti ti-clock"></i>25 min</div></div></div>
+            <div class="rcard"><div class="rcImg ic-sage"><i class="ti ti-salad"></i></div><div class="rcB"><div class="rcT">Chicken quinoa bowl</div><div class="rcM">540 kcal · 38g protein</div><div class="rcTime"><i class="ti ti-clock"></i>20 min</div></div></div>
+            <div class="rcard"><div class="rcImg ic-gold"><i class="ti ti-bowl"></i></div><div class="rcB"><div class="rcT">Greek yogurt & berries</div><div class="rcM">320 kcal · 24g protein</div><div class="rcTime"><i class="ti ti-clock"></i>5 min</div></div></div>
+            <div class="rcard"><div class="rcImg ic-sky"><i class="ti ti-egg"></i></div><div class="rcB"><div class="rcT">Veggie egg muffins</div><div class="rcM">210 kcal · 18g protein</div><div class="rcTime"><i class="ti ti-clock"></i>30 min</div></div></div>
+          </div>
+        </div>
+        <div class="tab"><a><i class="ti ti-home"></i>Today</a><a class="on"><i class="ti ti-book"></i>Recipes</a><a><i class="ti ti-calendar"></i>Plan</a><a><i class="ti ti-shopping-cart"></i>Shop</a><a><i class="ti ti-activity"></i>Stats</a></div>
+      </div>
+      <div class="cap">Recipes</div>
+    </div>
+
+    <!-- 3 RECIPE DETAIL -->
+    <div class="frame">
+      <div class="phone">
+        <div class="sb"><span>8:42</span><span class="r"><i class="ti ti-wifi"></i><i class="ti ti-battery-3"></i></span></div>
+        <div class="body" style="padding-top:8px">
+          <div class="hero2 ic-clay"><span class="rbtn"><i class="ti ti-chevron-left"></i></span><span class="rbtn"><i class="ti ti-heart"></i></span><i class="ti ti-fish big"></i></div>
+          <div style="padding-top:14px"><div class="eyebrow">Dinner · high protein</div><div class="htitle sm" style="margin-top:4px">Grilled salmon & greens</div></div>
+          <div class="stats4">
+            <div class="stat"><b>610</b><span>kcal</span></div>
+            <div class="stat"><b>42g</b><span>protein</span></div>
+            <div class="stat"><b>25m</b><span>time</span></div>
+            <div class="stat"><b>2</b><span>serves</span></div>
+          </div>
+          <div class="sectlbl" style="margin-top:2px">Ingredients</div>
+          <div class="ing"><span class="d"></span>2 salmon fillets</div>
+          <div class="ing"><span class="d"></span>200g tenderstem broccoli</div>
+          <div class="ing"><span class="d"></span>1 tbsp olive oil · lemon · garlic</div>
+          <div class="sectlbl">Method</div>
+          <div class="step"><b>1</b><p>Heat a griddle. Toss broccoli in oil, char 4 min.</p></div>
+          <div class="step"><b>2</b><p>Grill salmon skin-side down 4 min, flip 3 min.</p></div>
+        </div>
+        <div style="flex:none;display:flex;gap:9px;padding:11px 16px 16px;background:var(--surface);border-top:1px solid var(--line)">
+          <button class="btn" style="flex:1"><i class="ti ti-calendar-plus"></i>Add to plan</button>
+          <button class="btn ghost" style="flex:none;width:50px"><i class="ti ti-shopping-cart"></i></button>
+        </div>
+      </div>
+      <div class="cap">Recipe detail</div>
+    </div>
+
+    <!-- 4 MEAL PREP -->
+    <div class="frame">
+      <div class="phone">
+        <div class="sb"><span>8:42</span><span class="r"><i class="ti ti-wifi"></i><i class="ti ti-battery-3"></i></span></div>
+        <div class="body">
+          <div class="scrhead"><div><div class="eyebrow">This week</div><div class="htitle">Meal plan</div></div><span class="iconbtn"><i class="ti ti-chevron-right"></i></span></div>
+          <div class="days">
+            <div class="day on"><b>M</b><span>8</span></div>
+            <div class="day"><b>T</b><span>9</span></div>
+            <div class="day"><b>W</b><span>10</span></div>
+            <div class="day"><b>T</b><span>11</span></div>
+            <div class="day"><b>F</b><span>12</span></div>
+            <div class="day"><b>S</b><span>13</span></div>
+            <div class="day"><b>S</b><span>14</span><span class="dot"></span></div>
+          </div>
+          <div class="banner"><span class="ic ic-clay" style="width:32px;height:32px;font-size:16px"><i class="ti ti-tools-kitchen-2"></i></span><div><div class="bt">Prep day Sunday</div><div class="bs">Batch-cook 6 meals ahead</div></div></div>
+          <div class="mealcard"><span class="ic ic-sage" style="border-radius:12px"><i class="ti ti-bowl"></i></span><div class="mc1"><div class="me">Breakfast</div><div class="mr">Greek yogurt bowl</div></div><span class="mkcal">320</span></div>
+          <div class="mealcard"><span class="ic ic-clay" style="border-radius:12px"><i class="ti ti-salad"></i></span><div class="mc1"><div class="me">Lunch</div><div class="mr">Chicken quinoa bowl</div></div><span class="mkcal">540</span></div>
+          <div class="mealcard"><span class="ic ic-sky" style="border-radius:12px"><i class="ti ti-fish"></i></span><div class="mc1"><div class="me">Dinner</div><div class="mr">Salmon & greens</div></div><span class="mkcal">610</span></div>
+          <div class="plabel" style="margin-top:13px"><span>Daily total</span><span style="color:var(--sage-d)">1,470 / 1,900 kcal</span></div>
+          <div class="pbar"><i style="width:77%"></i></div>
+        </div>
+        <div class="tab"><a><i class="ti ti-home"></i>Today</a><a><i class="ti ti-book"></i>Recipes</a><a class="on"><i class="ti ti-calendar"></i>Plan</a><a><i class="ti ti-shopping-cart"></i>Shop</a><a><i class="ti ti-activity"></i>Stats</a></div>
+      </div>
+      <div class="cap">Meal plan</div>
+    </div>
+
+    <!-- 5 COOKING TASKS -->
+    <div class="frame">
+      <div class="phone">
+        <div class="sb"><span>8:42</span><span class="r"><i class="ti ti-wifi"></i><i class="ti ti-battery-3"></i></span></div>
+        <div class="body">
+          <div class="scrhead"><div><div class="eyebrow">Sunday · 6 tasks · ~90 min</div><div class="htitle sm" style="margin-top:3px">Batch prep</div></div><span class="iconbtn"><i class="ti ti-chevron-left"></i></span></div>
+          <div class="plabel"><span>2 of 6 done</span><span>33%</span></div>
+          <div class="pbar" style="margin-bottom:14px"><i style="width:33%"></i></div>
+          <div class="active">
+            <div class="ae">In progress</div>
+            <div class="an">Grill chicken breast</div>
+            <div class="timer"><i class="ti ti-flame"></i>12:00</div>
+          </div>
+          <div class="row"><span class="chk on"><i class="ti ti-check"></i></span><div class="rc"><div class="rt" style="color:var(--mute);text-decoration:line-through">Cook quinoa & rice</div></div><span class="tchip">15 min</span></div>
+          <div class="row"><span class="chk on"><i class="ti ti-check"></i></span><div class="rc"><div class="rt" style="color:var(--mute);text-decoration:line-through">Roast vegetables</div></div><span class="tchip">25 min</span></div>
+          <div class="row"><span class="chk empty"></span><div class="rc"><div class="rt">Portion into containers</div></div><span class="tchip">10 min</span></div>
+          <div class="row"><span class="chk empty"></span><div class="rc"><div class="rt">Make overnight oats</div></div><span class="tchip">8 min</span></div>
+        </div>
+        <div class="tab"><a><i class="ti ti-home"></i>Today</a><a><i class="ti ti-book"></i>Recipes</a><a class="on"><i class="ti ti-calendar"></i>Plan</a><a><i class="ti ti-shopping-cart"></i>Shop</a><a><i class="ti ti-activity"></i>Stats</a></div>
+      </div>
+      <div class="cap">Cooking tasks</div>
+    </div>
+
+    <!-- 6 SHOPPING -->
+    <div class="frame">
+      <div class="phone">
+        <div class="sb"><span>8:42</span><span class="r"><i class="ti ti-wifi"></i><i class="ti ti-battery-3"></i></span></div>
+        <div class="body">
+          <div class="scrhead"><div><div class="eyebrow">12 items · 4 done</div><div class="htitle">Shopping</div></div><span class="iconbtn"><i class="ti ti-plus"></i></span></div>
+          <div class="pbar" style="margin-bottom:4px"><i style="width:33%"></i></div>
+          <div class="cathead"><i class="ti ti-leaf" style="color:var(--sage)"></i>Produce</div>
+          <div class="item"><span class="chk empty"></span><span class="iname">Tenderstem broccoli</span><span class="qty">200g</span></div>
+          <div class="item"><span class="chk empty"></span><span class="iname">Baby spinach</span><span class="qty">1 bag</span></div>
+          <div class="item"><span class="chk on"><i class="ti ti-check"></i></span><span class="iname done">Avocado</span><span class="qty">2</span></div>
+          <div class="cathead"><i class="ti ti-meat" style="color:var(--clay)"></i>Protein</div>
+          <div class="item"><span class="chk empty"></span><span class="iname">Salmon fillets</span><span class="qty">4</span></div>
+          <div class="item"><span class="chk empty"></span><span class="iname">Chicken breast</span><span class="qty">800g</span></div>
+          <div class="item"><span class="chk on"><i class="ti ti-check"></i></span><span class="iname done">Free-range eggs</span><span class="qty">12</span></div>
+          <div class="cathead"><i class="ti ti-bread" style="color:var(--gold)"></i>Pantry</div>
+          <div class="item"><span class="chk empty"></span><span class="iname">Quinoa</span><span class="qty">500g</span></div>
+        </div>
+        <div class="tab"><a><i class="ti ti-home"></i>Today</a><a><i class="ti ti-book"></i>Recipes</a><a><i class="ti ti-calendar"></i>Plan</a><a class="on"><i class="ti ti-shopping-cart"></i>Shop</a><a><i class="ti ti-activity"></i>Stats</a></div>
+      </div>
+      <div class="cap">Shopping list</div>
+    </div>
+
+    <!-- 7 ANALYTICS -->
+    <div class="frame">
+      <div class="phone">
+        <div class="sb"><span>8:42</span><span class="r"><i class="ti ti-wifi"></i><i class="ti ti-battery-3"></i></span></div>
+        <div class="body">
+          <div class="scrhead"><div><div class="eyebrow">Last 30 days</div><div class="htitle">Progress</div></div><span class="iconbtn"><i class="ti ti-calendar"></i></span></div>
+          <div class="metrics">
+            <div class="metric"><div class="ml">Weight</div><b>−2.1</b><div class="mt">kg this month</div></div>
+            <div class="metric"><div class="ml">Workouts</div><b>38</b><div class="mt">of 45 days</div></div>
+            <div class="metric"><div class="ml">Fasting</div><b>12</b><div class="mt">day streak</div></div>
+          </div>
+          <div class="card" style="margin-bottom:12px">
+            <div class="ctitle">Body weight<span style="color:var(--sage-d);font-family:'Fraunces';font-size:15px">82.4 kg</span></div>
+            <svg width="100%" height="92" viewBox="0 0 268 92" preserveAspectRatio="none" role="img" aria-label="Body weight trending gently down over the month"><polyline points="6,84 6,20 44,26 80,32 116,28 152,40 188,46 224,54 260,58 260,84" fill="var(--sage-t)" stroke="none"/><polyline points="6,20 44,26 80,32 116,28 152,40 188,46 224,54 260,58" fill="none" stroke="var(--sage)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/><circle cx="260" cy="58" r="4.5" fill="var(--sage-d)"/></svg>
+          </div>
+          <div class="card" style="margin-bottom:12px">
+            <div class="ctitle">Consistency<span style="color:var(--mute);font-weight:600">Last 14 days</span></div>
+            <div class="dotgrid"><i></i><i></i><i class="p"></i><i></i><i></i><i></i><i></i><i></i><i class="n"></i><i></i><i></i><i class="p"></i><i></i><i></i></div>
+            <div class="legend"><span><i style="background:var(--sage)"></i>Complete</span><span><i style="background:var(--gold)"></i>Partial</span><span><i style="background:var(--canvas2)"></i>Missed</span></div>
+          </div>
+        </div>
+        <div class="tab"><a><i class="ti ti-home"></i>Today</a><a><i class="ti ti-book"></i>Recipes</a><a><i class="ti ti-calendar"></i>Plan</a><a><i class="ti ti-shopping-cart"></i>Shop</a><a class="on"><i class="ti ti-activity"></i>Stats</a></div>
+      </div>
+      <div class="cap">Analytics</div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,42 +1,61 @@
-// Design tokens for the 90-Day Health Tracker app.
-// Dark, premium fitness aesthetic.
+// Design tokens for the HealthTracker app.
+// Verdure — calm-wellness aesthetic (warm linen, sage, clay, sky, gold).
+// See design/verdure/DESIGN.md for the full system.
 
 export const Colors = {
   // Base surfaces
-  background: '#0D0F14',
-  surface: '#161A23',
-  surfaceElevated: '#1E2330',
-  border: '#2A3145',
+  background: '#F3EFE7',      // warm linen canvas
+  surface: '#FBF9F4',         // cards / nav surface
+  surfaceElevated: '#FFFFFF', // raised cards
+  border: '#E4DFD4',          // hairline (also used as Colors.border + alpha hex)
 
-  // Brand / accent
-  accent: '#00E5A0',        // Electric teal-green
-  accentDark: '#00B880',
-  accentGlow: 'rgba(0, 229, 160, 0.15)',
+  // Brand / accent — sage
+  accent: '#7C9A85',
+  accentDark: '#4E6B58',
+  accentGlow: 'rgba(124, 154, 133, 0.15)',
 
-  // Secondary accent
-  secondary: '#7C6FF7',     // Violet
-  secondaryGlow: 'rgba(124, 111, 247, 0.15)',
+  // Secondary accent — clay (food / warmth)
+  secondary: '#C98A6B',
+  secondaryGlow: 'rgba(201, 138, 107, 0.15)',
 
   // Semantic
-  success: '#00E5A0',
-  warning: '#FFB547',
-  danger: '#FF5C5C',
-  rest: '#4A5568',
+  success: '#7C9A85',
+  warning: '#C9A86A',         // muted gold
+  danger: '#C2705A',          // soft clay-red
+  rest: '#8FAABF',            // calm sky
 
   // Text
-  textPrimary: '#F0F4FF',
-  textSecondary: '#8892A4',
-  textMuted: '#4A5568',
+  textPrimary: '#2C352E',     // deep pine
+  textSecondary: '#5E665E',
+  textMuted: '#98A096',
 
   // Completion badges
-  badgeComplete: '#00E5A0',
-  badgePartial: '#FFB547',
-  badgeNone: '#2A3145',
-  badgeRest: '#4A5568',
+  badgeComplete: '#7C9A85',
+  badgePartial: '#C9A86A',
+  badgeNone: '#E4DFD4',
+  badgeRest: '#8FAABF',
+
+  // Verdure extended palette (new)
+  sage: '#7C9A85',
+  sageDeep: '#4E6B58',
+  sageTint: '#E6ECE2',
+  clay: '#C98A6B',
+  clayDeep: '#9A5E42',
+  clayTint: '#F3E6DB',
+  sky: '#8FAABF',
+  skyDeep: '#516675',
+  skyTint: '#E4EBF0',
+  gold: '#C9A86A',
+  goldDeep: '#8A7434',
+  goldTint: '#F1E8D4',
+  canvas: '#F3EFE7',
+  canvasSunken: '#ECE6DA',
 };
 
 export const Typography = {
-  fontFamily: undefined as string | undefined, // Uses system font; extend with expo-font if needed
+  fontFamily: undefined as string | undefined, // system default until the fonts unit lands
+  display: undefined as string | undefined,     // -> Fraunces (set in fonts unit)
+  body: undefined as string | undefined,         // -> Plus Jakarta Sans (set in fonts unit)
   sizes: {
     xs: 11,
     sm: 13,
@@ -65,9 +84,9 @@ export const Spacing = {
 };
 
 export const Radius = {
-  sm: 8,
-  md: 12,
-  lg: 16,
-  xl: 24,
+  sm: 10,
+  md: 16,
+  lg: 20,
+  xl: 26,
   full: 999,
 };


### PR DESCRIPTION
## Verdure UI overhaul — Unit 1: theme-tokens

Foundation unit for the calm-wellness "Verdure" redesign. No screen logic changes — this swaps the design tokens and adds the design board/docs so every later unit can build on a shared system.

### Changes
- **`src/theme/tokens.ts`** — replace the old dark fitness palette with the Verdure system: warm linen `canvas`, **sage** lead accent, **clay** (food), **sky** (rest), **gold** (streaks), each with deep/tint variants; softened `Radius` scale (cards 20–24); added `Typography` `display`/`body` slots. **All exported token keys are preserved**, so existing screens recolour automatically.
- **`design/verdure/`** — design board (`code.html`) + docs (`DESIGN.md`, `OVERHAUL_PLAN.md`, `PROJECT_BRIEF.md`) and the agent definitions driving the overhaul.

### Commits
- `docs(design): add Verdure design board and overhaul docs`
- `feat(theme): apply Verdure calm-wellness palette to tokens`

### Verification gate
- ✅ `npm run typecheck` — exit 0
- ✅ `npm test` — all green

Closes #225