### PR TITLE
Redesign · fonts: load Fraunces + Plus Jakarta Sans, wire Typography tokens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,15 @@ import {
 } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { useFonts } from 'expo-font';
+import {
+  Fraunces_600SemiBold,
+} from '@expo-google-fonts/fraunces';
+import {
+  PlusJakartaSans_500Medium,
+  PlusJakartaSans_600SemiBold,
+  PlusJakartaSans_700Bold,
+} from '@expo-google-fonts/plus-jakarta-sans';
 import { initDatabase } from './src/db/database';
 import AppNavigator from './src/navigation/AppNavigator';
 import { Colors, Typography } from './src/theme/tokens';
@@ -16,6 +25,13 @@ import { Colors, Typography } from './src/theme/tokens';
 export default function App() {
   const [dbReady, setDbReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [fontsLoaded, fontError] = useFonts({
+    Fraunces_600SemiBold,
+    PlusJakartaSans_500Medium,
+    PlusJakartaSans_600SemiBold,
+    PlusJakartaSans_700Bold,
+  });
 
   useEffect(() => {
     (async () => {
@@ -35,16 +51,17 @@ export default function App() {
     })();
   }, []);
 
-  if (error) {
+  if (error || fontError) {
+    const displayError = error ?? fontError?.message ?? 'Unknown font loading error';
     return (
       <View style={styles.splash}>
-        <Text style={styles.errorText}>❌ Failed to initialise database</Text>
-        <Text style={styles.errorDetail} selectable>{error}</Text>
+        <Text style={styles.errorText}>Failed to initialise app</Text>
+        <Text style={styles.errorDetail} selectable>{displayError}</Text>
       </View>
     );
   }
 
-  if (!dbReady) {
+  if (!dbReady || !fontsLoaded) {
     return (
       <View style={styles.splash}>
         <ActivityIndicator size="large" color={Colors.accent} />
@@ -68,10 +85,10 @@ export default function App() {
             notification: Colors.accent,
           },
           fonts: {
-            regular: { fontFamily: 'System', fontWeight: '400' },
-            medium: { fontFamily: 'System', fontWeight: '500' },
-            bold: { fontFamily: 'System', fontWeight: '700' },
-            heavy: { fontFamily: 'System', fontWeight: '900' },
+            regular: { fontFamily: Typography.body, fontWeight: '400' },
+            medium: { fontFamily: Typography.title, fontWeight: '500' },
+            bold: { fontFamily: Typography.title, fontWeight: '700' },
+            heavy: { fontFamily: Typography.label, fontWeight: '900' },
           },
         }}
       >

--- a/app.json
+++ b/app.json
@@ -28,7 +28,8 @@
       "favicon": "./assets/favicon.png"
     },
     "plugins": [
-      "expo-sqlite"
+      "expo-sqlite",
+      "expo-font"
     ],
     "extra": {
       "eas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "healthtracker",
       "version": "1.1.0",
       "dependencies": {
+        "@expo-google-fonts/fraunces": "^0.4.1",
+        "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/drawer": "^7.9.8",
@@ -17,6 +19,7 @@
         "expo": "~54.0.33",
         "expo-document-picker": "~14.0.8",
         "expo-file-system": "~19.0.21",
+        "expo-font": "~14.0.12",
         "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
@@ -1605,6 +1608,18 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@expo-google-fonts/fraunces": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/fraunces/-/fraunces-0.4.1.tgz",
+      "integrity": "sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/plus-jakarta-sans": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/plus-jakarta-sans/-/plus-jakarta-sans-0.4.2.tgz",
+      "integrity": "sha512-6LYVmVGwjQvH+uzzWlVc9+oMj4lkNQ41aymVDjO+x8aFk8kCye20wOyLomYMZaMezA++Uf1mZRCw3W3Fy/hxEA==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
@@ -8006,6 +8021,20 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-font": {
+      "version": "14.0.12",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
+      "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -8401,20 +8430,6 @@
       },
       "peerDependencies": {
         "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-font": {
-      "version": "14.0.11",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
-      "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
-      "license": "MIT",
-      "dependencies": {
-        "fontfaceobserver": "^2.1.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "@expo-google-fonts/fraunces": "^0.4.1",
+    "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/drawer": "^7.9.8",
@@ -22,6 +24,7 @@
     "expo": "~54.0.33",
     "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.21",
+    "expo-font": "~14.0.12",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -53,9 +53,16 @@ export const Colors = {
 };
 
 export const Typography = {
-  fontFamily: undefined as string | undefined, // system default until the fonts unit lands
-  display: undefined as string | undefined,     // -> Fraunces (set in fonts unit)
-  body: undefined as string | undefined,         // -> Plus Jakarta Sans (set in fonts unit)
+  // Plus Jakarta Sans 500 — base sans-serif for body text and UI
+  fontFamily: 'PlusJakartaSans_500Medium' as string,
+  // Fraunces 600 SemiBold — soft serif for display: screen titles, big numbers, recipe titles
+  display: 'Fraunces_600SemiBold' as string,
+  // Plus Jakarta Sans 500 — body copy, rows, descriptions
+  body: 'PlusJakartaSans_500Medium' as string,
+  // Plus Jakarta Sans 600 — section titles, nav labels
+  title: 'PlusJakartaSans_600SemiBold' as string,
+  // Plus Jakarta Sans 700 — micro-labels, uppercase caps (10px, +0.12em tracking, mute color)
+  label: 'PlusJakartaSans_700Bold' as string,
   sizes: {
     xs: 11,
     sm: 13,


### PR DESCRIPTION
## Summary

Unit 2 of the Verdure calm-wellness UI overhaul: load the two Verdure typefaces and wire them into the existing `Typography` token slots so the whole app renders in them.

### What changed

**Font packages installed** (`package.json`, `app.json`):
- `@expo-google-fonts/fraunces@0.4.1` — ships Fraunces TTFs + named asset exports
- `@expo-google-fonts/plus-jakarta-sans@0.4.2` — ships Plus Jakarta Sans TTFs + named asset exports
- `expo-font@14.0.12` — explicit dep (was transitive); `expo install` also registered its config plugin in `app.json` so TTFs are bundled on native builds

**Typography tokens** (`src/theme/tokens.ts`):
- `display` → `'Fraunces_600SemiBold'` — soft serif for screen titles, big numbers, recipe titles
- `body` → `'PlusJakartaSans_500Medium'` — body copy, rows, descriptions
- `fontFamily` → `'PlusJakartaSans_500Medium'` — base sans default
- `title` _(new slot)_ → `'PlusJakartaSans_600SemiBold'` — section headings, nav labels
- `label` _(new slot)_ → `'PlusJakartaSans_700Bold'` — micro-labels (10px uppercase, +0.12em tracking)

All pre-existing token keys (`Colors`, `Spacing`, `Radius`, `Typography.sizes`, `Typography.weights`) are unchanged.

**App.tsx**:
- Imports `useFonts` from `expo-font` and the four required font assets
- Render is blocked until **both** fonts are loaded AND the DB is initialised (loading spinner shown for either; existing DB-init gating preserved)
- Font load errors surface alongside DB errors in the error splash screen
- `NavigationContainer` theme fonts wired to `Typography.body / .title / .label` (Plus Jakarta Sans), replacing the old `'System'` placeholders

### Verification

- `npm run typecheck` — exit 0
- `npm test` — 2 suites, 2 tests, all green

Closes #229