### PR TITLE
Redesign · bioforce-modal — Verdure restyle

### DIFF
--- a/src/components/BioForceModal.tsx
+++ b/src/components/BioForceModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Modal,
   View,
@@ -13,30 +13,51 @@ import {
   Linking,
 } from 'react-native';
 import { getBioForceLibrary, BioForceExercise } from '../db/database';
+import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
+import Button from './Button';
+import Pill from './Pill';
 
 export interface BioForceModalProps {
   isVisible: boolean;
   onClose: () => void;
-  onAddWorkout: (workout: { 
-    id: string; 
-    name: string; 
-    muscle_group: string; 
-    sets: string; 
-    reps: string; 
+  onAddWorkout: (workout: {
+    id: string;
+    name: string;
+    muscle_group: string;
+    sets: string;
+    reps: string;
     completed: boolean;
   }) => void;
 }
+
+// ─── Difficulty helpers ───────────────────────────────────────────────────────
+
+/** Returns the Verdure tint bg colour for a difficulty level. */
+function difficultyTint(diff: string): string {
+  if (diff === 'Beginner') return Colors.sageTint;
+  if (diff === 'Intermediate') return Colors.goldTint;
+  return Colors.clayTint;
+}
+
+/** Returns the Verdure deep-shade text colour for a difficulty level. */
+function difficultyDeep(diff: string): string {
+  if (diff === 'Beginner') return Colors.sageDeep;
+  if (diff === 'Intermediate') return Colors.goldDeep;
+  return Colors.clayDeep;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
 
 export default function BioForceModal({ isVisible, onClose, onAddWorkout }: BioForceModalProps) {
   const [library, setLibrary] = useState<BioForceExercise[]>([]);
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  
+
   // Filters
   const [selMuscleGroups, setSelMuscleGroups] = useState<string[]>([]);
   const [selDifficulties, setSelDifficulties] = useState<string[]>([]);
   const [selAttachments, setSelAttachments] = useState<string[]>([]);
-  
+
   const [sortBy, setSortBy] = useState<'A-Z' | 'EasyFirst' | 'HardFirst' | 'MuscleGroup'>('A-Z');
   const [selectedEx, setSelectedEx] = useState<BioForceExercise | null>(null);
 
@@ -56,8 +77,10 @@ export default function BioForceModal({ isVisible, onClose, onAddWorkout }: BioF
   }, [search]);
 
   // Derived filter options
-  const allMuscleGroups = useMemo(() => Array.from(new Set(library.map(e => e.muscleGroup))).sort(), [library]);
-  const allAttachments = useMemo(() => Array.from(new Set(library.map(e => e.attachment))).sort(), [library]);
+  const allMuscleGroups = useMemo(
+    () => Array.from(new Set(library.map(e => e.muscleGroup))).sort(),
+    [library],
+  );
   const allDifficulties = ['Beginner', 'Intermediate', 'Advanced'];
 
   // Filtered & Sorted List
@@ -66,10 +89,11 @@ export default function BioForceModal({ isVisible, onClose, onAddWorkout }: BioF
 
     if (debouncedSearch) {
       const lower = debouncedSearch.toLowerCase();
-      list = list.filter(e => 
-        e.title.toLowerCase().includes(lower) ||
-        e.description.toLowerCase().includes(lower) ||
-        e.muscleGroup.toLowerCase().includes(lower)
+      list = list.filter(
+        e =>
+          e.title.toLowerCase().includes(lower) ||
+          e.description.toLowerCase().includes(lower) ||
+          e.muscleGroup.toLowerCase().includes(lower),
       );
     }
 
@@ -86,8 +110,8 @@ export default function BioForceModal({ isVisible, onClose, onAddWorkout }: BioF
     list = [...list].sort((a, b) => {
       if (sortBy === 'A-Z') return a.title.localeCompare(b.title);
       if (sortBy === 'MuscleGroup') return a.muscleGroup.localeCompare(b.muscleGroup);
-      
-      const diffVal = (d: string) => d === 'Beginner' ? 1 : d === 'Intermediate' ? 2 : 3;
+
+      const diffVal = (d: string) => (d === 'Beginner' ? 1 : d === 'Intermediate' ? 2 : 3);
       if (sortBy === 'EasyFirst') return diffVal(a.difficulty) - diffVal(b.difficulty);
       if (sortBy === 'HardFirst') return diffVal(b.difficulty) - diffVal(a.difficulty);
       return 0;
@@ -101,12 +125,6 @@ export default function BioForceModal({ isVisible, onClose, onAddWorkout }: BioF
     else setList([...list, val]);
   };
 
-  const getDifficultyColor = (diff: string) => {
-    if (diff === 'Beginner') return '#22C55E';
-    if (diff === 'Intermediate') return '#F59E0B';
-    return '#EF4444';
-  };
-  
   const handleWatchVideo = (url: string) => {
     if (url) Linking.openURL(url).catch(console.error);
   };
@@ -119,471 +137,625 @@ export default function BioForceModal({ isVisible, onClose, onAddWorkout }: BioF
         muscle_group: selectedEx.muscleGroup,
         sets: selectedEx.sets || '3',
         reps: selectedEx.reps || '10',
-        completed: false
+        completed: false,
       });
       setSelectedEx(null);
       onClose();
     }
   };
 
-  // 1) Details Panel
+  // ─── 1) Details Panel ──────────────────────────────────────────────────────
+
   if (selectedEx) {
     return (
       <Modal visible={isVisible} animationType="slide" transparent={true}>
-        <SafeAreaView style={styles.modalBg}>
-          <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{flex:1}}>
-          <View style={styles.detailsContainer}>
-            <View style={styles.header}>
-              <TouchableOpacity onPress={() => setSelectedEx(null)}>
-                <Text style={styles.backBtn}>← Back</Text>
-              </TouchableOpacity>
-              <Text style={styles.selectedTitle} numberOfLines={1}>{selectedEx.title}</Text>
-            </View>
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            style={styles.flex}
+          >
+            <View style={styles.overlay}>
+              <View style={styles.sheet}>
+                {/* Drag handle */}
+                <View style={styles.dragHandle} />
 
-            <ScrollView contentContainerStyle={{ padding: 16 }}>
-              {/* Quick Stats Row */}
-              <View style={styles.statsRow}>
-                <View style={styles.statBox}>
-                  <Text style={styles.statLabel}>Muscle</Text>
-                  <Text style={styles.statValue}>{selectedEx.muscleGroup}</Text>
-                </View>
-                <View style={[styles.statBox, { borderLeftWidth: 1, borderColor: '#334155' }]}>
-                  <Text style={styles.statLabel}>Difficulty</Text>
-                  <Text style={[styles.statValue, { color: getDifficultyColor(selectedEx.difficulty) }]}>
-                    {selectedEx.difficulty}
+                {/* Header */}
+                <View style={styles.header}>
+                  <TouchableOpacity onPress={() => setSelectedEx(null)} hitSlop={styles.hitSlop}>
+                    <Text style={styles.backBtn}>← Back</Text>
+                  </TouchableOpacity>
+                  <Text style={styles.selectedTitle} numberOfLines={1}>
+                    {selectedEx.title}
                   </Text>
                 </View>
-              </View>
 
-              <View style={styles.statsRow}>
-                <View style={[styles.statBox, { borderTopWidth: 1, borderColor: '#334155' }]}>
-                  <Text style={styles.statLabel}>Rec. Sets</Text>
-                  <Text style={styles.statValue}>{selectedEx.sets}</Text>
-                </View>
-                <View style={[styles.statBox, { borderLeftWidth: 1, borderTopWidth: 1, borderColor: '#334155' }]}>
-                  <Text style={styles.statLabel}>Rec. Reps</Text>
-                  <Text style={styles.statValue}>{selectedEx.reps}</Text>
-                </View>
-              </View>
-              
-              <View style={styles.statsRow}>
-                <View style={[styles.statBox, { borderTopWidth: 1, borderColor: '#334155' }]}>
-                  <Text style={styles.statLabel}>Attachment</Text>
-                  <Text style={styles.statValue}>{selectedEx.attachment}</Text>
-                </View>
-                <View style={[styles.statBox, { borderLeftWidth: 1, borderTopWidth: 1, borderColor: '#334155' }]}>
-                  <Text style={styles.statLabel}>Position</Text>
-                  <Text style={styles.statValue}>{selectedEx.cablePosition}</Text>
-                </View>
-              </View>
-
-              {/* Video Button */}
-              {selectedEx.videoId ? (
-                <TouchableOpacity 
-                  style={styles.videoThumbnail} 
-                  onPress={() => handleWatchVideo(`https://www.youtube.com/watch?v=${selectedEx.videoId}`)}
-                >
-                  <View style={styles.playIconContainer}>
-                    <Text style={styles.playIcon}>▶</Text>
+                <ScrollView contentContainerStyle={styles.detailScroll}>
+                  {/* Quick Stats Grid */}
+                  <View style={styles.statsGrid}>
+                    <View style={styles.statCell}>
+                      <Text style={styles.statLabel}>MUSCLE</Text>
+                      <Text style={styles.statValue}>{selectedEx.muscleGroup}</Text>
+                    </View>
+                    <View style={[styles.statCell, styles.statCellBorderLeft]}>
+                      <Text style={styles.statLabel}>DIFFICULTY</Text>
+                      <Text
+                        style={[styles.statValue, { color: difficultyDeep(selectedEx.difficulty) }]}
+                      >
+                        {selectedEx.difficulty}
+                      </Text>
+                    </View>
+                    <View style={[styles.statCell, styles.statCellBorderTop]}>
+                      <Text style={styles.statLabel}>REC. SETS</Text>
+                      <Text style={styles.statValue}>{selectedEx.sets}</Text>
+                    </View>
+                    <View style={[styles.statCell, styles.statCellBorderLeft, styles.statCellBorderTop]}>
+                      <Text style={styles.statLabel}>REC. REPS</Text>
+                      <Text style={styles.statValue}>{selectedEx.reps}</Text>
+                    </View>
+                    <View style={[styles.statCell, styles.statCellBorderTop]}>
+                      <Text style={styles.statLabel}>ATTACHMENT</Text>
+                      <Text style={styles.statValue}>{selectedEx.attachment}</Text>
+                    </View>
+                    <View style={[styles.statCell, styles.statCellBorderLeft, styles.statCellBorderTop]}>
+                      <Text style={styles.statLabel}>POSITION</Text>
+                      <Text style={styles.statValue}>{selectedEx.cablePosition}</Text>
+                    </View>
                   </View>
-                  <Text style={styles.videoText}>Watch Tutorial</Text>
-                </TouchableOpacity>
-              ) : (
-                <View style={[styles.videoThumbnail, { backgroundColor: '#1E293B' }]}>
-                  <Text style={styles.videoText}>No Video Available</Text>
-                </View>
-              )}
 
-              {/* Descriptions & Details */}
-              <View style={styles.section}>
-                <Text style={styles.sectionTitle}>Description</Text>
-                <Text style={styles.bodyText}>{selectedEx.description}</Text>
+                  {/* Video Button */}
+                  {selectedEx.videoId ? (
+                    <TouchableOpacity
+                      style={styles.videoButton}
+                      onPress={() =>
+                        handleWatchVideo(
+                          `https://www.youtube.com/watch?v=${selectedEx.videoId}`,
+                        )
+                      }
+                      activeOpacity={0.75}
+                    >
+                      <View style={styles.playIconContainer}>
+                        <Text style={styles.playIcon}>▶</Text>
+                      </View>
+                      <Text style={styles.videoText}>Watch Tutorial</Text>
+                    </TouchableOpacity>
+                  ) : (
+                    <View style={[styles.videoButton, styles.videoButtonEmpty]}>
+                      <Text style={styles.videoTextMuted}>No Video Available</Text>
+                    </View>
+                  )}
+
+                  {/* Description */}
+                  <View style={styles.section}>
+                    <Text style={styles.sectionTitle}>Description</Text>
+                    <Text style={styles.bodyText}>{selectedEx.description}</Text>
+                  </View>
+
+                  {/* Muscles Engaged */}
+                  {(selectedEx.primaryMuscles.length > 0 ||
+                    selectedEx.secondaryMuscles.length > 0) && (
+                    <View style={styles.section}>
+                      <Text style={styles.sectionTitle}>Muscles Engaged</Text>
+                      <Text style={styles.bodyText}>
+                        <Text style={styles.bodyTextBold}>Primary: </Text>
+                        {selectedEx.primaryMuscles.join(', ') || 'None'}
+                      </Text>
+                      <Text style={styles.bodyText}>
+                        <Text style={styles.bodyTextBold}>Secondary: </Text>
+                        {selectedEx.secondaryMuscles.join(', ') || 'None'}
+                      </Text>
+                    </View>
+                  )}
+
+                  {/* Pro Tips */}
+                  {selectedEx.tips && selectedEx.tips.length > 0 && (
+                    <View style={styles.section}>
+                      <Text style={styles.sectionTitle}>Pro Tips</Text>
+                      {selectedEx.tips.map((t, i) => (
+                        <Text key={i} style={styles.bodyText}>
+                          • {t}
+                        </Text>
+                      ))}
+                    </View>
+                  )}
+                </ScrollView>
+
+                {/* Add button */}
+                <View style={styles.addPanel}>
+                  <Button
+                    title="Add to Today's Checklist"
+                    variant="primary"
+                    onPress={handleAdd}
+                  />
+                </View>
               </View>
-
-              {(selectedEx.primaryMuscles.length > 0 || selectedEx.secondaryMuscles.length > 0) && (
-                <View style={styles.section}>
-                  <Text style={styles.sectionTitle}>Muscles Engaged</Text>
-                  <Text style={styles.bodyText}>
-                    <Text style={{ fontWeight: 'bold', color: '#CBD5E1' }}>Primary: </Text>
-                    {selectedEx.primaryMuscles.join(', ') || 'None'}
-                  </Text>
-                  <Text style={styles.bodyText}>
-                    <Text style={{ fontWeight: 'bold', color: '#CBD5E1' }}>Secondary: </Text>
-                    {selectedEx.secondaryMuscles.join(', ') || 'None'}
-                  </Text>
-                </View>
-              )}
-
-              {selectedEx.tips && selectedEx.tips.length > 0 && (
-                <View style={styles.section}>
-                  <Text style={styles.sectionTitle}>Pro Tips</Text>
-                  {selectedEx.tips.map((t, i) => (
-                    <Text key={i} style={styles.bodyText}>• {t}</Text>
-                  ))}
-                </View>
-              )}
-
-            </ScrollView>
-
-            <View style={styles.addPanel}>
-              <TouchableOpacity style={styles.addButton} onPress={handleAdd}>
-                <Text style={styles.addButtonText}>Add to Today's Checklist</Text>
-              </TouchableOpacity>
             </View>
-
-          </View>
           </KeyboardAvoidingView>
         </SafeAreaView>
       </Modal>
     );
   }
 
-  // 2) Main List Panel
+  // ─── 2) Main List Panel ────────────────────────────────────────────────────
+
   return (
     <Modal visible={isVisible} animationType="slide" transparent={true}>
-      <SafeAreaView style={styles.modalBg}>
-        <View style={styles.container}>
-          <View style={styles.header}>
-            <Text style={styles.title}>Bio Force Library</Text>
-            <TouchableOpacity onPress={onClose}>
-              <Text style={styles.closeBtn}>Close</Text>
-            </TouchableOpacity>
-          </View>
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.overlay}>
+          <View style={styles.sheet}>
+            {/* Drag handle */}
+            <View style={styles.dragHandle} />
 
-          {/* Search */}
-          <View style={styles.searchWrap}>
-            <TextInput
-              style={styles.searchInput}
-              placeholder="Search 113+ exercises..."
-              placeholderTextColor="#64748B"
-              value={search}
-              onChangeText={setSearch}
-            />
-            {search.length > 0 && (
-              <TouchableOpacity onPress={() => setSearch('')} style={styles.clearSearch}>
-                <Text style={styles.clearSearchText}>×</Text>
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>Bio Force Library</Text>
+              <TouchableOpacity onPress={onClose} hitSlop={styles.hitSlop}>
+                <Text style={styles.closeBtn}>Close</Text>
               </TouchableOpacity>
-            )}
-          </View>
+            </View>
 
-          {/* Filters Top Bar */}
-          <View>
-            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.filterScroll}>
-              
-              {/* Difficulities */}
-              {allDifficulties.map(diff => {
-                const active = selDifficulties.includes(diff);
-                return (
-                  <TouchableOpacity 
-                    key={diff} 
-                    style={[styles.chip, active && { backgroundColor: getDifficultyColor(diff) + '40', borderColor: getDifficultyColor(diff) }]}
-                    onPress={() => toggleFilter(selDifficulties, setSelDifficulties, diff)}
-                  >
-                    <Text style={[styles.chipText, active && { color: getDifficultyColor(diff) }]}>{diff}</Text>
-                  </TouchableOpacity>
-                );
-              })}
+            {/* Search */}
+            <View style={styles.searchWrap}>
+              <TextInput
+                style={styles.searchInput}
+                placeholder="Search 113+ exercises..."
+                placeholderTextColor={Colors.textMuted}
+                value={search}
+                onChangeText={setSearch}
+              />
+              {search.length > 0 && (
+                <TouchableOpacity
+                  onPress={() => setSearch('')}
+                  style={styles.clearSearch}
+                  hitSlop={styles.hitSlop}
+                >
+                  <Text style={styles.clearSearchText}>×</Text>
+                </TouchableOpacity>
+              )}
+            </View>
 
-              {/* Muscles Dropdown equivalent via horizontal scroll */}
-              {allMuscleGroups.map(grp => {
-                const active = selMuscleGroups.includes(grp);
-                return (
-                  <TouchableOpacity 
-                    key={grp} 
-                    style={[styles.chip, active && styles.chipActive]}
-                    onPress={() => toggleFilter(selMuscleGroups, setSelMuscleGroups, grp)}
-                  >
-                    <Text style={[styles.chipText, active && styles.chipTextActive]}>{grp}</Text>
-                  </TouchableOpacity>
-                );
-              })}
+            {/* Filter chips */}
+            <View>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.filterScroll}
+              >
+                {allDifficulties.map(diff => {
+                  const active = selDifficulties.includes(diff);
+                  return (
+                    <TouchableOpacity
+                      key={diff}
+                      style={[
+                        styles.chip,
+                        active && {
+                          backgroundColor: difficultyTint(diff),
+                          borderColor: difficultyDeep(diff),
+                        },
+                      ]}
+                      onPress={() => toggleFilter(selDifficulties, setSelDifficulties, diff)}
+                      activeOpacity={0.75}
+                    >
+                      <Text
+                        style={[
+                          styles.chipText,
+                          active && { color: difficultyDeep(diff) },
+                        ]}
+                      >
+                        {diff}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
 
+                {allMuscleGroups.map(grp => {
+                  const active = selMuscleGroups.includes(grp);
+                  return (
+                    <TouchableOpacity
+                      key={grp}
+                      style={[styles.chip, active && styles.chipActive]}
+                      onPress={() => toggleFilter(selMuscleGroups, setSelMuscleGroups, grp)}
+                      activeOpacity={0.75}
+                    >
+                      <Text style={[styles.chipText, active && styles.chipTextActive]}>
+                        {grp}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </ScrollView>
+            </View>
+
+            {/* Results count */}
+            <View style={styles.resultsHeader}>
+              <Text style={styles.resultsCount}>
+                {filteredList.length} exercise{filteredList.length !== 1 ? 's' : ''} found
+              </Text>
+            </View>
+
+            {/* Exercise list */}
+            <ScrollView contentContainerStyle={styles.listContent}>
+              {filteredList.map(ex => (
+                <TouchableOpacity
+                  key={ex.id}
+                  style={styles.card}
+                  onPress={() => setSelectedEx(ex)}
+                  activeOpacity={0.75}
+                >
+                  <View style={styles.cardHeader}>
+                    <Text style={styles.cardTitle}>{ex.title}</Text>
+                  </View>
+                  <View style={styles.cardBadges}>
+                    <Pill label={ex.difficulty} accent={difficultyAccent(ex.difficulty)} />
+                    <Text style={styles.badgeSeparator}>•</Text>
+                    <Text style={styles.badgeMuscle}>{ex.muscleGroup}</Text>
+                    <Text style={styles.badgeSeparator}>•</Text>
+                    <Text style={styles.badgeAttachment}>{ex.attachment}</Text>
+                  </View>
+                </TouchableOpacity>
+              ))}
+              {filteredList.length === 0 && (
+                <View style={styles.emptyState}>
+                  <Text style={styles.emptyStateText}>
+                    No exercises match your search filters.
+                  </Text>
+                </View>
+              )}
             </ScrollView>
           </View>
-
-          <View style={styles.resultsHeader}>
-            <Text style={styles.resultsCount}>{filteredList.length} Exercises found</Text>
-          </View>
-
-          {/* List */}
-          <ScrollView contentContainerStyle={styles.listContent}>
-            {filteredList.map(ex => (
-              <TouchableOpacity key={ex.id} style={styles.card} onPress={() => setSelectedEx(ex)}>
-                <View style={styles.cardHeader}>
-                  <Text style={styles.cardTitle}>{ex.title}</Text>
-                </View>
-                <View style={styles.cardBadges}>
-                  <Text style={[styles.badgeText, { color: getDifficultyColor(ex.difficulty) }]}>{ex.difficulty}</Text>
-                  <Text style={styles.badgeTextSeparator}>•</Text>
-                  <Text style={styles.badgeTextMuscle}>{ex.muscleGroup}</Text>
-                  <Text style={styles.badgeTextSeparator}>•</Text>
-                  <Text style={styles.badgeTextAttachment}>{ex.attachment}</Text>
-                </View>
-              </TouchableOpacity>
-            ))}
-            {filteredList.length === 0 && (
-              <View style={styles.emptyState}>
-                <Text style={styles.emptyStateText}>No exercises match your search filters.</Text>
-              </View>
-            )}
-          </ScrollView>
-
         </View>
       </SafeAreaView>
     </Modal>
   );
 }
 
+/** Maps difficulty string to a Verdure accent family for the Pill component. */
+function difficultyAccent(diff: string): 'sage' | 'gold' | 'clay' {
+  if (diff === 'Beginner') return 'sage';
+  if (diff === 'Intermediate') return 'gold';
+  return 'clay';
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
 const styles = StyleSheet.create({
-  modalBg: {
+  // Layout scaffolding
+  safeArea: {
     flex: 1,
-    backgroundColor: '#0F172A', // Dark Slate
   },
-  container: {
+  flex: {
     flex: 1,
-    backgroundColor: '#0F172A',
   },
+  // Pine-tinted overlay scrim (DESIGN.md §2 — not pure black)
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(44,53,46,0.45)',
+    justifyContent: 'flex-end',
+  },
+  // Bottom sheet surface
+  sheet: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: Radius.xl,
+    borderTopRightRadius: Radius.xl,
+    maxHeight: '92%',
+    overflow: 'hidden',
+  },
+  // Drag handle
+  dragHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: Radius.full,
+    backgroundColor: Colors.line2,
+    alignSelf: 'center',
+    marginTop: Spacing.md,
+    marginBottom: Spacing.sm,
+  },
+
+  // Header row
   header: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: 16,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
     borderBottomWidth: 1,
-    borderBottomColor: '#1E293B',
+    borderBottomColor: Colors.line,
   },
   title: {
-    color: '#F8FAFC',
-    fontSize: 20,
-    fontWeight: 'bold',
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.xl,
+    color: Colors.textPrimary,
+    letterSpacing: -0.5,
   },
   closeBtn: {
-    color: '#3B82F6', // Blue
-    fontSize: 16,
-    fontWeight: '600',
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.sageDeep,
+    fontWeight: Typography.weights.semibold,
   },
-  // Search
+
+  // Search bar
   searchWrap: {
-    padding: 16,
-    paddingBottom: 8,
-    position: 'relative'
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.sm,
+    position: 'relative',
   },
   searchInput: {
-    backgroundColor: '#1E293B',
-    color: '#F8FAFC',
-    borderRadius: 8,
-    padding: 12,
-    fontSize: 16,
+    backgroundColor: Colors.canvasSunken,
+    color: Colors.textPrimary,
+    borderRadius: Radius.md,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    paddingRight: Spacing.xxl + Spacing.md,
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
     borderWidth: 1,
-    borderColor: '#334155'
+    borderColor: Colors.line2,
   },
   clearSearch: {
     position: 'absolute',
-    right: 28,
-    top: 26,
+    right: Spacing.lg + Spacing.sm,
+    top: Spacing.md + Spacing.md,
     width: 24,
     height: 24,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#334155',
-    borderRadius: 12,
+    backgroundColor: Colors.line2,
+    borderRadius: Radius.full,
   },
   clearSearchText: {
-    color: '#F8FAFC',
-    fontWeight: 'bold',
+    fontFamily: Typography.title,
+    color: Colors.textSecondary,
+    fontWeight: Typography.weights.bold,
     lineHeight: 18,
   },
-  // Filters
+
+  // Filter chips
   filterScroll: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    gap: 8,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.sm,
   },
   chip: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 16,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xs + 2,
+    borderRadius: Radius.full,
     borderWidth: 1,
-    borderColor: '#334155',
-    backgroundColor: '#1E293B',
-    marginRight: 8, // Using gap in ScrollView is sometimes tricky, use margin
+    borderColor: Colors.line2,
+    backgroundColor: Colors.canvasSunken,
+    marginRight: Spacing.sm,
   },
   chipActive: {
-    backgroundColor: '#3B82F640', // 25% opacity blue
-    borderColor: '#3B82F6',
+    backgroundColor: Colors.sageTint,
+    borderColor: Colors.sageDeep,
   },
   chipText: {
-    color: '#94A3B8',
-    fontSize: 13,
-    fontWeight: '500',
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    fontWeight: Typography.weights.medium,
   },
   chipTextActive: {
-    color: '#60A5FA',
+    color: Colors.sageDeep,
+    fontWeight: Typography.weights.semibold,
   },
+
+  // Results count
   resultsHeader: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.sm,
   },
   resultsCount: {
-    color: '#94A3B8',
-    fontSize: 14,
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
   },
-  // List
+
+  // Exercise list
   listContent: {
-    padding: 16,
-    paddingTop: 0,
-    paddingBottom: 40,
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.xs,
+    paddingBottom: Spacing.xxl + Spacing.lg,
   },
   card: {
-    backgroundColor: '#1E293B',
-    padding: 16,
-    borderRadius: 12,
-    marginBottom: 12,
+    backgroundColor: Colors.surface,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: Radius.md,
+    marginBottom: Spacing.sm,
     borderWidth: 1,
-    borderColor: '#334155'
+    borderColor: Colors.line,
   },
   cardHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 4,
+    marginBottom: Spacing.sm,
   },
   cardTitle: {
-    color: '#F8FAFC',
-    fontSize: 16,
-    fontWeight: 'bold',
-    flex: 1,
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+    fontWeight: Typography.weights.semibold,
   },
   cardBadges: {
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
+    gap: Spacing.xs,
   },
-  badgeText: {
-    fontSize: 13,
-    fontWeight: '600',
+  badgeSeparator: {
+    fontFamily: Typography.body,
+    color: Colors.textMuted,
+    fontSize: Typography.sizes.xs,
+    marginHorizontal: Spacing.xs,
   },
-  badgeTextMuscle: {
-    color: '#3B82F6', // Blue
-    fontSize: 13,
-    fontWeight: '500',
+  badgeMuscle: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.sageDeep,
+    fontWeight: Typography.weights.medium,
   },
-  badgeTextAttachment: {
-    color: '#94A3B8', // Slate
-    fontSize: 13,
+  badgeAttachment: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
   },
-  badgeTextSeparator: {
-    color: '#475569',
-    marginHorizontal: 6,
-    fontSize: 10,
-  },
+
+  // Empty state
   emptyState: {
-    padding: 32,
+    paddingVertical: Spacing.xxl,
     alignItems: 'center',
   },
   emptyStateText: {
-    color: '#64748B',
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textMuted,
     textAlign: 'center',
   },
-  
-  // Details Panel
-  detailsContainer: {
-    flex: 1,
-    backgroundColor: '#0F172A',
+
+  // ─── Details Panel ─────────────────────────────────────────────────────────
+
+  detailScroll: {
+    padding: Spacing.lg,
+    paddingBottom: Spacing.xxl,
   },
+
+  // Back button + title
   backBtn: {
-    color: '#3B82F6',
-    fontSize: 16,
-    fontWeight: '600',
-    width: 60,
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.sageDeep,
+    fontWeight: Typography.weights.semibold,
+    minWidth: 60,
   },
   selectedTitle: {
-    color: '#F8FAFC',
-    fontSize: 18,
-    fontWeight: 'bold',
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.lg,
+    color: Colors.textPrimary,
+    letterSpacing: -0.4,
     flex: 1,
     textAlign: 'center',
-    marginRight: 60, // offset for back btn
+    marginRight: 60, // offset balances back button width
   },
-  statsRow: {
+
+  // Stats grid
+  statsGrid: {
     flexDirection: 'row',
-    backgroundColor: '#1E293B',
-    marginHorizontal: -16, // Bleed to edges
-    paddingHorizontal: 16,
+    flexWrap: 'wrap',
+    backgroundColor: Colors.canvasSunken,
+    borderRadius: Radius.md,
+    overflow: 'hidden',
+    marginBottom: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.line,
   },
-  statBox: {
+  statCell: {
     flex: 1,
-    paddingVertical: 12,
-    paddingHorizontal: 8,
+    minWidth: '50%',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+  },
+  statCellBorderLeft: {
+    borderLeftWidth: 1,
+    borderLeftColor: Colors.line,
+  },
+  statCellBorderTop: {
+    borderTopWidth: 1,
+    borderTopColor: Colors.line,
   },
   statLabel: {
-    color: '#64748B',
-    fontSize: 12,
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs - 1,
+    color: Colors.textMuted,
     textTransform: 'uppercase',
-    marginBottom: 2,
+    letterSpacing: 0.5,
+    marginBottom: Spacing.xs,
   },
   statValue: {
-    color: '#F8FAFC',
-    fontSize: 15,
-    fontWeight: 'bold',
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.md,
+    color: Colors.textPrimary,
+    fontWeight: Typography.weights.semibold,
   },
-  videoThumbnail: {
+
+  // Video button / placeholder
+  videoButton: {
     height: 160,
-    backgroundColor: '#000000',
-    borderRadius: 12,
-    marginVertical: 20,
+    backgroundColor: Colors.sageTint,
+    borderRadius: Radius.md,
+    marginBottom: Spacing.lg,
     justifyContent: 'center',
     alignItems: 'center',
     borderWidth: 1,
-    borderColor: '#334155'
+    borderColor: Colors.line,
+  },
+  videoButtonEmpty: {
+    backgroundColor: Colors.canvasSunken,
   },
   playIconContainer: {
     width: 48,
     height: 48,
-    borderRadius: 24,
-    backgroundColor: '#EF4444', // YouTube red
+    borderRadius: Radius.full,
+    backgroundColor: Colors.sage,
     justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: 8,
+    marginBottom: Spacing.sm,
   },
   playIcon: {
-    color: '#FFFFFF',
-    fontSize: 20,
-    marginLeft: 4, // Visual balance for play triangle
+    color: Colors.surface,
+    fontSize: Typography.sizes.lg,
+    marginLeft: Spacing.xs, // visual balance for play triangle
   },
   videoText: {
-    color: '#F8FAFC',
-    fontSize: 14,
-    fontWeight: '500',
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.sageDeep,
+    fontWeight: Typography.weights.semibold,
   },
+  videoTextMuted: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textMuted,
+  },
+
+  // Section blocks
   section: {
-    marginBottom: 20,
+    marginBottom: Spacing.lg,
   },
   sectionTitle: {
-    color: '#F8FAFC',
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 8,
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.md,
+    color: Colors.textPrimary,
+    fontWeight: Typography.weights.semibold,
+    marginBottom: Spacing.sm,
   },
   bodyText: {
-    color: '#94A3B8',
-    fontSize: 15,
-    lineHeight: 22,
-    marginBottom: 4,
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textSecondary,
+    lineHeight: Typography.sizes.sm * 1.55,
+    marginBottom: Spacing.xs,
   },
+  bodyTextBold: {
+    fontFamily: Typography.title,
+    color: Colors.textPrimary,
+    fontWeight: Typography.weights.semibold,
+  },
+
+  // Add-to-checklist panel
   addPanel: {
-    padding: 16,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    paddingBottom: Spacing.xl,
     borderTopWidth: 1,
-    borderTopColor: '#1E293B',
-    backgroundColor: '#0F172A',
+    borderTopColor: Colors.line,
+    backgroundColor: Colors.surface,
   },
-  addButton: {
-    backgroundColor: '#F97316', // Orange
-    paddingVertical: 16,
-    borderRadius: 12,
-    alignItems: 'center',
-  },
-  addButtonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: 'bold',
-  }
+
+  // Hit slop for small touch targets
+  hitSlop: {
+    top: 8,
+    bottom: 8,
+    left: 8,
+    right: 8,
+  } as const,
 });


### PR DESCRIPTION
## Summary

Restyle `src/components/BioForceModal.tsx` — the last un-restyled surface in the app — to the Verdure calm-wellness design system. Eliminates all ~53 raw hex color literals and replaces them with `Colors`, `Spacing`, `Typography`, and `Radius` tokens.

### Visual changes

- **Modal container**: pine-tinted overlay scrim (`rgba(44,53,46,0.45)`), `surface` bg bottom sheet, `Radius.xl` rounded top corners, `line2` drag handle — matches the established bottom-sheet pattern from `MealPrepScreen`
- **Title**: Fraunces display font (`Typography.display`) for "Bio Force Library" and detail-panel exercise title
- **Stats grid (detail panel)**: `canvasSunken` bg + `line` dividers; labels in `Typography.label` uppercase; values in `Typography.title`
- **Difficulty indicators**: `sage`/`gold`/`clay` tint families via `difficultyTint()` + `difficultyDeep()` helpers; exercise cards use the shared `Pill` component
- **Filter chips**: `sageTint`/`sageDeep` when active, `canvasSunken`/`textMuted` when inactive; `Radius.full` pill shape
- **Search input**: `canvasSunken` bg, `line2` border, `textMuted` placeholder
- **Video button**: `sageTint` bg, `sage`-coloured play button (replaces YouTube red)
- **Back / Close links**: `sageDeep` (replaces blue `#3B82F6`)
- **Add CTA**: shared `Button` component, `primary` (sage) variant
- **Body / description text**: `textSecondary`; bold labels in `textPrimary`

### Behavior preserved

- Props API (`BioForceModalProps`) unchanged
- Open/close behavior unchanged
- All data queries and filter/sort logic unchanged
- All emoji glyphs kept (outline-icon migration is a separate track)

### Verification

- `npm run typecheck` — exit 0
- `npm test` — 10/10 tests green
- Zero raw hex literals remain in the file

Closes #253