### PR TITLE
Redesign · icons — outline icon migration + tokenize raw hex

### DIFF
--- a/__mocks__/@expo/vector-icons.js
+++ b/__mocks__/@expo/vector-icons.js
@@ -1,0 +1,27 @@
+// Stub for @expo/vector-icons — icon families pull in native font loading
+// which is unavailable in Jest's node testEnvironment. Return trivial function
+// components for every icon family used in the app.
+const React = require('react');
+
+function stubIcon() {
+  return null;
+}
+
+module.exports = {
+  Ionicons: stubIcon,
+  Feather: stubIcon,
+  MaterialIcons: stubIcon,
+  FontAwesome: stubIcon,
+  FontAwesome5: stubIcon,
+  AntDesign: stubIcon,
+  Entypo: stubIcon,
+  EvilIcons: stubIcon,
+  Foundation: stubIcon,
+  MaterialCommunityIcons: stubIcon,
+  Octicons: stubIcon,
+  SimpleLineIcons: stubIcon,
+  Zocial: stubIcon,
+  createIconSet: jest.fn(() => stubIcon),
+  createIconSetFromFontello: jest.fn(() => stubIcon),
+  createIconSetFromIcoMoon: jest.fn(() => stubIcon),
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
     '^expo/src/winter(/.*)?$': '<rootDir>/__mocks__/expo-winter.js',
     '^expo-sqlite(/.*)?$': '<rootDir>/__mocks__/expo-sqlite.js',
     '^expo-asset(/.*)?$': '<rootDir>/__mocks__/expo-asset.js',
+    '^@expo/vector-icons(/.*)?$': '<rootDir>/__mocks__/@expo/vector-icons.js',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo-google-fonts/fraunces": "^0.4.1",
         "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
+        "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/drawer": "^7.9.8",
@@ -2336,6 +2337,17 @@
       "resolved": "https://registry.npmjs.org/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
+    },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
@@ -8327,17 +8339,6 @@
         "expo": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
-      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@expo-google-fonts/fraunces": "^0.4.1",
     "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
+    "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/drawer": "^7.9.8",

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { createDrawerNavigator } from '@react-navigation/drawer';
-import { Text, View, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { DrawerActions, useNavigation } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
 import DashboardScreen from '../screens/DashboardScreen';
 import OverviewScreen from '../screens/OverviewScreen';
 import AnalyticsDashboardScreen from '../screens/AnalyticsDashboardScreen';
@@ -27,21 +28,25 @@ function RecipesStackScreen() {
   );
 }
 
-const DRAWER_ICONS: Record<string, string> = {
-  Today: '🏋️',
-  Schedule: '📅',
-  Analytics: '📊',
-  'Meal Prep': '🥗',
-  Template: '✏️',
-  Recipes: '🍽️',
-  Shopping: '🛒',
-  'Cooking Tasks': '👨‍🍳',
+type IoniconsName = React.ComponentProps<typeof Ionicons>['name'];
+
+const DRAWER_ICONS: Record<string, IoniconsName> = {
+  Today: 'barbell-outline',
+  Schedule: 'calendar-outline',
+  Analytics: 'stats-chart-outline',
+  'Meal Prep': 'nutrition-outline',
+  Template: 'create-outline',
+  Recipes: 'restaurant-outline',
+  Shopping: 'cart-outline',
+  'Cooking Tasks': 'flame-outline',
 };
 
-function DrawerIcon({ label }: { label: string }) {
+function DrawerIcon({ label, focused }: { label: string; focused?: boolean }) {
+  const iconName: IoniconsName = DRAWER_ICONS[label] ?? 'ellipse-outline';
+  const color = focused ? Colors.sageDeep : Colors.textSecondary;
   return (
     <View style={styles.iconContainer}>
-      <Text style={styles.iconEmoji}>{DRAWER_ICONS[label] ?? '•'}</Text>
+      <Ionicons name={iconName} size={20} color={color} />
     </View>
   );
 }
@@ -99,7 +104,9 @@ export default function AppNavigator() {
         drawerLabelStyle: styles.drawerLabel,
         // Rounded active item background per Verdure shape language
         drawerItemStyle: styles.drawerItem,
-        drawerIcon: () => <DrawerIcon label={route.name} />,
+        drawerIcon: ({ focused }: { focused: boolean }) => (
+          <DrawerIcon label={route.name} focused={focused} />
+        ),
       })}
     >
       <Drawer.Screen name="Today" component={DashboardScreen} />
@@ -132,7 +139,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     width: 28,
   },
-  iconEmoji: { fontSize: 20 },
 
   // Right-side hamburger — token color, no raw hex
   burgerBtn: {

--- a/src/screens/CookingTasksScreen.tsx
+++ b/src/screens/CookingTasksScreen.tsx
@@ -21,6 +21,7 @@ import {
   ActivityIndicator,
   RefreshControl,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
@@ -39,6 +40,7 @@ import {
   Button,
   ScreenHeader,
 } from '../components';
+import { iconChipIconColor } from '../components/IconChip';
 
 // ─── Task Card ───────────────────────────────────────────────────────────────
 
@@ -52,7 +54,7 @@ function TaskCard({
   onRemove: () => void;
 }) {
   const cookIcon = (
-    <Text style={{ fontSize: 18, color: Colors.clayDeep }}>{'🍳'}</Text>
+    <Ionicons name="flame-outline" size={20} color={iconChipIconColor('clay')} />
   );
 
   return (

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -13,6 +13,7 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 
 import {
   DailyLogEntry,
@@ -38,6 +39,7 @@ import {
   Button,
   BioForceModal,
 } from '../components';
+import { iconChipIconColor } from '../components/IconChip';
 
 // ─── Verdure circle checkbox ──────────────────────────────────────────────────
 // Replaces old square Checkbox: 24px circle, empty = line2 ring, done = sage fill
@@ -151,7 +153,7 @@ function HammerSection({
       <Card style={styles.sectionHeaderCard}>
         <View style={styles.sectionHeaderRow}>
           <IconChip
-            icon={<Text style={styles.chipIcon}>🏋️</Text>}
+            icon={<Ionicons name="barbell-outline" size={20} color={iconChipIconColor('sage')} />}
             accent="sage"
           />
           <View style={styles.sectionHeaderText}>
@@ -417,7 +419,7 @@ export default function DashboardScreen() {
           <Card style={styles.sectionHeaderCard}>
             <View style={styles.sectionHeaderRow}>
               <IconChip
-                icon={<Text style={styles.chipIcon}>🚶</Text>}
+                icon={<Ionicons name="walk-outline" size={20} color={iconChipIconColor('sky')} />}
                 accent="sky"
               />
               <View style={styles.sectionHeaderText}>
@@ -445,7 +447,7 @@ export default function DashboardScreen() {
           <Card style={styles.sectionHeaderCard}>
             <View style={styles.sectionHeaderRow}>
               <IconChip
-                icon={<Text style={styles.chipIcon}>⏱</Text>}
+                icon={<Ionicons name="time-outline" size={20} color={iconChipIconColor('gold')} />}
                 accent="gold"
               />
               <View style={styles.sectionHeaderText}>
@@ -468,7 +470,7 @@ export default function DashboardScreen() {
           <Card style={styles.sectionHeaderCard}>
             <View style={styles.sectionHeaderRow}>
               <IconChip
-                icon={<Text style={styles.chipIcon}>🍽</Text>}
+                icon={<Ionicons name="restaurant-outline" size={20} color={iconChipIconColor('clay')} />}
                 accent="clay"
               />
               <View style={styles.sectionHeaderText}>
@@ -510,7 +512,7 @@ export default function DashboardScreen() {
           <Card style={styles.weightCard}>
             <View style={styles.sectionHeaderRow}>
               <IconChip
-                icon={<Text style={styles.chipIcon}>⚖</Text>}
+                icon={<Ionicons name="scale-outline" size={20} color={iconChipIconColor('sage')} />}
                 accent="sage"
               />
               <View style={styles.weightContent}>
@@ -621,7 +623,7 @@ const styles = StyleSheet.create({
   heroCount: {
     fontFamily: Typography.display,
     fontSize: Typography.sizes.hero,
-    color: '#FFFFFF',
+    color: Colors.textOnAccent,
     lineHeight: Typography.sizes.hero,
     letterSpacing: -1,
   },
@@ -642,7 +644,7 @@ const styles = StyleSheet.create({
   headerTitle: {
     fontFamily: Typography.display,
     fontSize: Typography.sizes.xl,
-    color: '#FFFFFF',
+    color: Colors.textOnAccent,
     letterSpacing: -0.5,
     lineHeight: Typography.sizes.xl * 1.2,
   },
@@ -657,7 +659,7 @@ const styles = StyleSheet.create({
   mealPrepPillText: {
     fontFamily: Typography.label,
     fontSize: Typography.sizes.xs,
-    color: '#FFFFFF',
+    color: Colors.textOnAccent,
     letterSpacing: 0.5,
   },
 
@@ -727,9 +729,6 @@ const styles = StyleSheet.create({
     color: Colors.textPrimary,
     lineHeight: Typography.sizes.sm * 1.45,
   },
-
-  // ── Chip icon ─────────────────────────────────────────────────────────────
-  chipIcon: { fontSize: 18 },
 
   // ── Verdure circle checkbox ───────────────────────────────────────────────
   checkboxRow: {

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -757,7 +757,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.sage,
   },
   circleCheckMark: {
-    color: '#FFFFFF',
+    color: Colors.textOnAccent,
     fontSize: 13,
     fontFamily: Typography.title,
     lineHeight: 16,

--- a/src/screens/MealPrepScreen.tsx
+++ b/src/screens/MealPrepScreen.tsx
@@ -9,6 +9,7 @@ import {
   FlatList,
   TextInput,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
 import {
@@ -31,6 +32,7 @@ import {
   Button,
   ScreenHeader,
 } from '../components';
+import { iconChipIconColor } from '../components/IconChip';
 
 // ─── Helpers ──────────────────────────────────────────────────
 
@@ -185,7 +187,7 @@ export default function MealPrepScreen() {
             {/* Header row: icon chip + title + portions pill */}
             <View style={styles.invCardHeader}>
               <IconChip
-                icon={<Text style={styles.chipIcon}>🍲</Text>}
+                icon={<Ionicons name="restaurant-outline" size={20} color={iconChipIconColor('clay')} />}
                 accent="clay"
                 size={40}
               />
@@ -372,7 +374,13 @@ function MealSlot({
       {plan ? (
         <View style={styles.assignedRow}>
           <IconChip
-            icon={<Text style={styles.chipIcon}>{label === 'Lunch' ? '🥗' : '🍽'}</Text>}
+            icon={
+              <Ionicons
+                name={label === 'Lunch' ? 'nutrition-outline' : 'restaurant-outline'}
+                size={18}
+                color={iconChipIconColor('clay')}
+              />
+            }
             accent="clay"
             size={36}
           />
@@ -774,10 +782,6 @@ const styles = StyleSheet.create({
     lineHeight: 16,
   },
 
-  // ── Chip icon text ─────────────────────────────────────────
-  chipIcon: {
-    fontSize: 18,
-  },
 
   // ── Inventory card ─────────────────────────────────────────
   inventoryCard: {

--- a/src/screens/OverviewScreen.tsx
+++ b/src/screens/OverviewScreen.tsx
@@ -9,6 +9,7 @@ import {
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import {
   DailyLogEntry,
   getRollingWindow,
@@ -24,6 +25,7 @@ import {
   Button,
   ScreenHeader,
 } from '../components';
+import { iconChipIconColor } from '../components/IconChip';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -58,11 +60,13 @@ const BADGE_LABEL: Record<BadgeStatus, string> = {
   rest:    'Rest',
 };
 
-const BADGE_EMOJI: Record<BadgeStatus, string> = {
-  full:    '✅',
-  partial: '🟡',
-  none:    '⬜',
-  rest:    '💤',
+type IoniconsName = React.ComponentProps<typeof Ionicons>['name'];
+
+const BADGE_ICON: Record<BadgeStatus, IoniconsName> = {
+  full:    'checkmark-circle-outline',
+  partial: 'ellipse-outline',
+  none:    'ellipse-outline',
+  rest:    'moon-outline',
 };
 
 // ─── Date helpers ─────────────────────────────────────────────────────────────
@@ -105,9 +109,14 @@ function DayRow({
   );
 
   // Status IconChip as Row's trailing slot
+  const statusIconName: IoniconsName = future ? 'time-outline' : BADGE_ICON[status];
+  const statusIconColor = future ? Colors.skyDeep : (
+    accent === 'sage' ? Colors.sageDeep :
+    accent === 'gold' ? Colors.goldDeep : Colors.skyDeep
+  );
   const statusChip = (
     <IconChip
-      icon={<Text style={styles.chipEmoji}>{future ? '🕐' : BADGE_EMOJI[status]}</Text>}
+      icon={<Ionicons name={statusIconName} size={18} color={statusIconColor} />}
       accent={future ? 'sky' : accent}
       size={36}
     />
@@ -122,8 +131,8 @@ function DayRow({
     <TouchableOpacity onPress={onPress} activeOpacity={0.7}>
       <Row
         leading={dateColumn}
-        title={`🏋️ ${entry.hammer_task}`}
-        subtitle={`🚶 ${subtitle}`}
+        title={entry.hammer_task}
+        subtitle={subtitle}
         trailing={statusChip}
         style={[
           styles.dayRow,
@@ -158,7 +167,13 @@ function DayDetailModal({
   function CompletionChip({ done }: { done: boolean }) {
     return (
       <IconChip
-        icon={<Text style={styles.chipEmoji}>{done ? '✓' : '○'}</Text>}
+        icon={
+          <Ionicons
+            name={done ? 'checkmark-circle-outline' : 'ellipse-outline'}
+            size={16}
+            color={iconChipIconColor(done ? 'sage' : 'sky')}
+          />
+        }
         accent={done ? 'sage' : 'sky'}
         size={32}
       />
@@ -183,7 +198,7 @@ function DayDetailModal({
                 )}
               </View>
               <Pill
-                label={future ? '🕐 Upcoming' : `${BADGE_EMOJI[status]} ${BADGE_LABEL[status]}`}
+                label={future ? 'Upcoming' : BADGE_LABEL[status]}
                 accent={future ? 'sky' : accent}
               />
             </View>
@@ -195,7 +210,7 @@ function DayDetailModal({
                 <Row
                   leading={
                     <IconChip
-                      icon={<Text style={styles.chipEmoji}>🚶</Text>}
+                      icon={<Ionicons name="walk-outline" size={18} color={iconChipIconColor('sky')} />}
                       accent="sky"
                       size={36}
                     />
@@ -215,7 +230,7 @@ function DayDetailModal({
                 <Row
                   leading={
                     <IconChip
-                      icon={<Text style={styles.chipEmoji}>🏋️</Text>}
+                      icon={<Ionicons name="barbell-outline" size={18} color={iconChipIconColor('sage')} />}
                       accent="sage"
                       size={36}
                     />
@@ -236,7 +251,7 @@ function DayDetailModal({
                   <Row
                     leading={
                       <IconChip
-                        icon={<Text style={styles.chipEmoji}>⏱️</Text>}
+                        icon={<Ionicons name="time-outline" size={18} color={iconChipIconColor('gold')} />}
                         accent="gold"
                         size={36}
                       />
@@ -258,7 +273,7 @@ function DayDetailModal({
                   <Row
                     leading={
                       <IconChip
-                        icon={<Text style={styles.chipEmoji}>🥗</Text>}
+                        icon={<Ionicons name="nutrition-outline" size={18} color={iconChipIconColor('clay')} />}
                         accent="clay"
                         size={36}
                       />
@@ -453,9 +468,6 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.sage,
     marginTop: 2,
   },
-
-  // Emoji inside IconChip
-  chipEmoji: { fontSize: 16 },
 
   // ── Modal ─────────────────────────────────────────────────────────────────
   modalOverlay: {

--- a/src/screens/RecipeDetailScreen.tsx
+++ b/src/screens/RecipeDetailScreen.tsx
@@ -7,10 +7,12 @@ import {
   TouchableOpacity,
   Alert,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
 import { getRecipeById, Recipe, addShoppingListItem, insertCookingTask } from '../db/database';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { Card, Row, IconChip, Button } from '../components';
+import { iconChipIconColor } from '../components/IconChip';
 
 // ─── Stat Chip ────────────────────────────────────────────────────────────────
 
@@ -108,7 +110,7 @@ export default function RecipeDetailScreen() {
         <Card style={styles.heroCard}>
           <View style={styles.heroInner}>
             <IconChip
-              icon={<Text style={styles.heroEmoji}>{'🍽'}</Text>}
+              icon={<Ionicons name="restaurant-outline" size={24} color={iconChipIconColor('clay')} />}
               accent="clay"
               size={48}
             />
@@ -214,7 +216,7 @@ export default function RecipeDetailScreen() {
             <Card style={styles.tipCard}>
               <View style={styles.tipInner}>
                 <IconChip
-                  icon={<Text style={styles.tipEmoji}>{'❄'}</Text>}
+                  icon={<Ionicons name="snow-outline" size={18} color={iconChipIconColor('sky')} />}
                   accent="sky"
                   size={36}
                 />
@@ -279,9 +281,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-start',
     gap: Spacing.md,
-  },
-  heroEmoji: {
-    fontSize: 22,
   },
   heroTextBlock: {
     flex: 1,
@@ -453,9 +452,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-start',
     gap: Spacing.md,
-  },
-  tipEmoji: {
-    fontSize: 18,
   },
   tipText: {
     fontFamily: Typography.body,

--- a/src/screens/RecipesScreen.tsx
+++ b/src/screens/RecipesScreen.tsx
@@ -8,10 +8,12 @@ import {
   ScrollView,
   TextInput,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
 import { getRecipes, Recipe } from '../db/database';
 import { useNavigation } from '@react-navigation/native';
 import { Card, IconChip, ScreenHeader } from '../components';
+import { iconChipIconColor } from '../components/IconChip';
 
 // ─── Category → accent family mapping ────────────────────────────────────────
 
@@ -43,13 +45,14 @@ const ACCENT_META_COLOR: Record<AccentKey, string> = {
   sky:  Colors.skyDeep,
 };
 
-// Category emoji stand-ins (no new native deps)
-const CATEGORY_EMOJI: Record<string, string> = {
-  'All':            '🍽',
-  'Fresh & Fridge': '🥗',
-  'Quick Cook':     '⚡',
-  'Freezer Batch':  '❄',
-  'Freezer Sauce':  '🫙',
+type IoniconsName = React.ComponentProps<typeof Ionicons>['name'];
+
+const CATEGORY_ICON: Record<string, IoniconsName> = {
+  'All':            'restaurant-outline',
+  'Fresh & Fridge': 'nutrition-outline',
+  'Quick Cook':     'flash-outline',
+  'Freezer Batch':  'snow-outline',
+  'Freezer Sauce':  'flask-outline',
 };
 
 const CATEGORIES = ['All', 'Fresh & Fridge', 'Quick Cook', 'Freezer Batch', 'Freezer Sauce'];
@@ -66,7 +69,7 @@ function RecipeCard({
   const accent = categoryAccent(item.category);
   const metaColor = ACCENT_META_COLOR[accent];
   const imgBg = ACCENT_IMG_BG[accent];
-  const emoji = CATEGORY_EMOJI[item.category] ?? '🍽';
+  const iconName: IoniconsName = CATEGORY_ICON[item.category] ?? 'restaurant-outline';
 
   return (
     <TouchableOpacity
@@ -78,7 +81,7 @@ function RecipeCard({
         {/* Tinted icon band */}
         <View style={[styles.cardImgBand, { backgroundColor: imgBg }]}>
           <IconChip
-            icon={<Text style={styles.cardEmoji}>{emoji}</Text>}
+            icon={<Ionicons name={iconName} size={22} color={iconChipIconColor(accent)} />}
             accent={accent}
             size={44}
           />
@@ -145,7 +148,7 @@ export default function RecipesScreen() {
       {/* Search bar */}
       <View style={styles.searchRow}>
         <View style={styles.searchBar}>
-          <Text style={styles.searchIcon}>{'🔍'}</Text>
+          <Ionicons name="search-outline" size={16} color={Colors.textMuted} />
           <TextInput
             style={styles.searchInput}
             placeholder="Search recipes & ingredients"
@@ -232,10 +235,6 @@ const styles = StyleSheet.create({
     paddingVertical: Spacing.sm,
     gap: Spacing.sm,
   },
-  searchIcon: {
-    fontSize: 16,
-    color: Colors.textMuted,
-  },
   searchInput: {
     flex: 1,
     fontFamily: Typography.body,
@@ -295,9 +294,6 @@ const styles = StyleSheet.create({
     height: 72,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  cardEmoji: {
-    fontSize: 24,
   },
   cardBody: {
     padding: Spacing.md,

--- a/src/screens/ShoppingListScreen.tsx
+++ b/src/screens/ShoppingListScreen.tsx
@@ -16,6 +16,7 @@ import {
   TouchableOpacity,
   Alert,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
 import {
@@ -31,26 +32,29 @@ import {
   Button,
   ScreenHeader,
 } from '../components';
+import { iconChipIconColor } from '../components/IconChip';
 
 // ─── Category inference ───────────────────────────────────────────────────────
 
 type CategoryKey = 'Produce' | 'Protein' | 'Dairy' | 'Pantry' | 'Drinks' | 'Other';
 
+type IoniconsName = React.ComponentProps<typeof Ionicons>['name'];
+
 interface CategoryMeta {
   label: CategoryKey;
   /** Accent family for IconChip + header tint */
   accent: 'sage' | 'clay' | 'sky' | 'gold';
-  /** Unicode symbol rendered inside the IconChip */
-  icon: string;
+  /** Ionicons outline icon name for the category */
+  icon: IoniconsName;
 }
 
 const CATEGORIES: CategoryMeta[] = [
-  { label: 'Produce',  accent: 'sage', icon: '🥦' },
-  { label: 'Protein',  accent: 'clay', icon: '🥩' },
-  { label: 'Dairy',    accent: 'sky',  icon: '🥛' },
-  { label: 'Pantry',   accent: 'gold', icon: '🌾' },
-  { label: 'Drinks',   accent: 'sky',  icon: '💧' },
-  { label: 'Other',    accent: 'sage', icon: '🛒' },
+  { label: 'Produce',  accent: 'sage', icon: 'leaf-outline' },
+  { label: 'Protein',  accent: 'clay', icon: 'barbell-outline' },
+  { label: 'Dairy',    accent: 'sky',  icon: 'water-outline' },
+  { label: 'Pantry',   accent: 'gold', icon: 'archive-outline' },
+  { label: 'Drinks',   accent: 'sky',  icon: 'cafe-outline' },
+  { label: 'Other',    accent: 'sage', icon: 'cart-outline' },
 ];
 
 const PRODUCE_KEYWORDS = [
@@ -189,7 +193,7 @@ function CategorySection({
   const { meta, items } = group;
 
   const iconNode = (
-    <Text style={{ fontSize: 16 }}>{meta.icon}</Text>
+    <Ionicons name={meta.icon} size={14} color={iconChipIconColor(meta.accent)} />
   );
 
   return (
@@ -308,7 +312,7 @@ export default function ShoppingListScreen() {
         {totalCount === 0 ? (
           <View style={styles.emptyContainer}>
             <View style={styles.emptyIconWrap}>
-              <Text style={styles.emptyIcon}>🛒</Text>
+              <Ionicons name="cart-outline" size={32} color={Colors.sageDeep} />
             </View>
             <Text style={styles.emptyTitle}>Nothing here yet</Text>
             <Text style={styles.emptySubtitle}>
@@ -470,9 +474,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginBottom: Spacing.sm,
-  },
-  emptyIcon: {
-    fontSize: 32,
   },
   emptyTitle: {
     fontFamily: Typography.display,

--- a/src/screens/TemplateEditorScreen.tsx
+++ b/src/screens/TemplateEditorScreen.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   Modal,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import {
   WeeklyTemplateDay,
   Exercise,
@@ -168,7 +169,7 @@ function ExerciseItem({
   onEdit: () => void;
   onDelete: () => void;
 }) {
-  const meta = `${exercise.sets}×${exercise.reps}${exercise.videoUrl ? '  · 📹 Video' : ''}`;
+  const meta = `${exercise.sets}×${exercise.reps}${exercise.videoUrl ? '  · Video' : ''}`;
   return (
     <Row
       title={exercise.name}
@@ -181,7 +182,7 @@ function ExerciseItem({
             onPress={onEdit}
             hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
           >
-            <Text style={styles.exEditBtnText}>✏️</Text>
+            <Ionicons name="create-outline" size={16} color={Colors.sageDeep} />
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.exDeleteBtn}
@@ -305,10 +306,10 @@ function TemplateCard({ day, onSave, onExercisesChange }: TemplateCardProps) {
           <Text style={styles.dayLabel}>{DAY_LABELS[day.day_of_week]}</Text>
           <View style={styles.tagRow}>
             {day.is_rest_day && (
-              <Pill label="💤 Rest Day" accent="sky" />
+              <Pill label="Rest Day" accent="sky" />
             )}
             {day.is_meal_prep_day && (
-              <Pill label="🥗 Meal Prep" accent="clay" />
+              <Pill label="Meal Prep" accent="clay" />
             )}
           </View>
         </View>
@@ -316,7 +317,7 @@ function TemplateCard({ day, onSave, onExercisesChange }: TemplateCardProps) {
 
       {/* Walking Task */}
       <View style={styles.fieldGroup}>
-        <Text style={styles.fieldLabel}>🚶 WALKING TASK</Text>
+        <Text style={styles.fieldLabel}>WALKING TASK</Text>
         <TextInput
           style={styles.input}
           value={walk}
@@ -329,7 +330,7 @@ function TemplateCard({ day, onSave, onExercisesChange }: TemplateCardProps) {
 
       {/* Hammer Task label */}
       <View style={styles.fieldGroup}>
-        <Text style={styles.fieldLabel}>🏋️ HAMMER TASK (base label)</Text>
+        <Text style={styles.fieldLabel}>HAMMER TASK (base label)</Text>
         <TextInput
           style={styles.input}
           value={hammer}
@@ -362,7 +363,7 @@ function TemplateCard({ day, onSave, onExercisesChange }: TemplateCardProps) {
       {/* ── Exercises ────────────────────────────────────────────────── */}
       <View style={styles.exSection}>
         <View style={styles.exSectionHeader}>
-          <Text style={styles.fieldLabel}>💪 EXERCISES ({exercises.length})</Text>
+          <Text style={styles.fieldLabel}>EXERCISES ({exercises.length})</Text>
           <Button
             title="+ Add"
             variant="ghost"
@@ -630,7 +631,6 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.sageTint,
     borderRadius: Radius.sm,
   },
-  exEditBtnText: { fontSize: 15 },
   exDeleteBtn: {
     width: 32, height: 32,
     alignItems: 'center', justifyContent: 'center',

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -54,6 +54,9 @@ export const Colors = {
   // Hairline border tokens (from DESIGN.md §2)
   line: 'rgba(44,53,46,0.08)',   // subtle hairline — depth via tone, not hard lines
   line2: 'rgba(44,53,46,0.15)',  // stronger border, empty checkbox ring
+
+  // White text on deep-accent fills (hero block, deep-sage panel)
+  textOnAccent: '#FFFFFF',
 };
 
 export const Typography = {


### PR DESCRIPTION
## Summary

- **Adds `@expo/vector-icons` dependency** (SDK-54-compatible `^15.0.3` via `npx expo install`) — this is a new native dependency and will trigger the EAS `build-check` workflow. The build must pass before merge.
- **Adds jest mock** (`__mocks__/@expo/vector-icons.js`) following the existing `expo-sqlite`/`expo-asset`/`expo-winter` pattern, with a `moduleNameMapper` entry in `jest.config.js` — all 10 existing tests stay green.
- **Replaces every emoji glyph** across all screens, components, and navigation with **Ionicons outline icons** (single consistent set, DESIGN.md §6). Icons are rendered via `<Ionicons name="…-outline" size={…} color={iconChipIconColor(accent)} />` inside `IconChip`, using the existing `iconChipIconColor()` helper for the deep-shade colour rule.
- **Tokenizes all remaining raw `#FFFFFF` literals** in `DashboardScreen` → `Colors.textOnAccent` (additive token, no existing keys changed).

## Files changed

| File | Change |
|---|---|
| `package.json` + lock | `@expo/vector-icons ^15.0.3` added |
| `__mocks__/@expo/vector-icons.js` | New jest stub |
| `jest.config.js` | `moduleNameMapper` entry for the stub |
| `src/theme/tokens.ts` | `Colors.textOnAccent = '#FFFFFF'` added |
| `src/navigation/AppNavigator.tsx` | `DRAWER_ICONS` → Ionicons names; `DrawerIcon` renders `<Ionicons>`; active/inactive tinting via `focused` prop |
| `src/screens/DashboardScreen.tsx` | All 5 `#FFFFFF` literals → token; 5 section chips → Ionicons |
| `src/screens/OverviewScreen.tsx` | `BADGE_EMOJI` → `BADGE_ICON`; inline emoji stripped from Row text; modal section chips → Ionicons; `CompletionChip` → Ionicons |
| `src/screens/TemplateEditorScreen.tsx` | Pill labels, field labels, video subtitle, edit button → Ionicons |
| `src/screens/RecipesScreen.tsx` | `CATEGORY_EMOJI` → `CATEGORY_ICON`; search bar emoji → `search-outline` |
| `src/screens/RecipeDetailScreen.tsx` | Hero chip + freezer-tip chip → Ionicons |
| `src/screens/MealPrepScreen.tsx` | Inventory card chip + meal slot chips → Ionicons |
| `src/screens/CookingTasksScreen.tsx` | `cookIcon` emoji → `flame-outline` |
| `src/screens/ShoppingListScreen.tsx` | Category icons (typed `IoniconsName`) + empty-state icon → Ionicons |

## Icon mapping used (Ionicons outline)

`barbell-outline` (gym/hammer), `walk-outline` (walking), `time-outline` (fasting/upcoming), `restaurant-outline` (meals/recipes), `nutrition-outline` (meal prep/lunch), `flame-outline` (cooking tasks), `cart-outline` (shopping/other), `scale-outline` (body weight), `calendar-outline` (schedule), `stats-chart-outline` (analytics), `create-outline` (template/edit), `snow-outline` (freezer), `search-outline` (search), `flash-outline` (quick cook), `flask-outline` (freezer sauce), `leaf-outline` (produce), `water-outline` (dairy), `archive-outline` (pantry), `cafe-outline` (drinks), `checkmark-circle-outline` / `ellipse-outline` / `moon-outline` (status badges).

## Verification

- `npm run typecheck` — exit 0
- `npm test` — 3 suites, 10 tests, all green
- `build-check` (EAS APK) will run on this PR because `package.json` changed — must pass before merge.

Closes #255