### PR TITLE
Recipes · create, edit & delete recipes (live macro recompute)

### DIFF
--- a/src/db/__tests__/recipeHelpers.test.ts
+++ b/src/db/__tests__/recipeHelpers.test.ts
@@ -1,0 +1,135 @@
+/**
+ * recipeHelpers.test.ts
+ *
+ * Unit tests for the recipe helper utilities added in issue #263:
+ *   - isSeededRecipe(id): returns true for r001–r100 ids, false for custom/mealdb
+ *   - Ingredient row ↔ RecipeIngredient round-trip logic (pure helper behaviour)
+ */
+
+import { isSeededRecipe } from '../database';
+
+// ─── isSeededRecipe ───────────────────────────────────────────────────────────
+
+describe('isSeededRecipe', () => {
+  it('returns true for r001 through r100 (seeded ids)', () => {
+    expect(isSeededRecipe('r001')).toBe(true);
+    expect(isSeededRecipe('r050')).toBe(true);
+    expect(isSeededRecipe('r100')).toBe(true);
+  });
+
+  it('returns false for custom-* ids', () => {
+    expect(isSeededRecipe('custom-1717000000000')).toBe(false);
+    expect(isSeededRecipe('custom-0')).toBe(false);
+  });
+
+  it('returns false for mealdb-* ids', () => {
+    expect(isSeededRecipe('mealdb-52772')).toBe(false);
+    expect(isSeededRecipe('mealdb-12345')).toBe(false);
+  });
+
+  it('returns false for ids that look similar but do not match the pattern', () => {
+    // Too many digits
+    expect(isSeededRecipe('r1000')).toBe(false);
+    // Too few digits
+    expect(isSeededRecipe('r01')).toBe(false);
+    // Wrong prefix
+    expect(isSeededRecipe('R001')).toBe(false);
+    // Empty string
+    expect(isSeededRecipe('')).toBe(false);
+  });
+});
+
+// ─── Ingredient row conversion helpers (pure logic, tested inline) ────────────
+
+/**
+ * These functions live inside RecipeEditorScreen but their logic is trivial
+ * and deterministic — test equivalent behaviour here rather than importing
+ * private helpers.
+ */
+
+interface IngRow { name: string; quantity: string; unit: string }
+interface Ingredient { name: string; baseQuantity: number; unit: string }
+
+function rowsToIngredients(rows: IngRow[]): Ingredient[] {
+  return rows
+    .filter((r) => r.name.trim() !== '' && parseFloat(r.quantity) > 0)
+    .map((r) => ({ name: r.name.trim(), baseQuantity: parseFloat(r.quantity) || 0, unit: r.unit }));
+}
+
+function ingredientsToRows(ingredients: Ingredient[]): IngRow[] {
+  return ingredients.map((ing) => ({
+    name: ing.name,
+    quantity: String(ing.baseQuantity),
+    unit: ing.unit,
+    key: 'test-key',
+  }));
+}
+
+describe('rowsToIngredients', () => {
+  it('converts valid rows to RecipeIngredient shape', () => {
+    const rows: IngRow[] = [
+      { name: 'Chicken breast', quantity: '200', unit: 'g' },
+      { name: 'Olive oil', quantity: '1', unit: 'tbsp' },
+    ];
+    const result = rowsToIngredients(rows);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ name: 'Chicken breast', baseQuantity: 200, unit: 'g' });
+    expect(result[1]).toEqual({ name: 'Olive oil', baseQuantity: 1, unit: 'tbsp' });
+  });
+
+  it('filters out rows with empty names', () => {
+    const rows: IngRow[] = [
+      { name: '', quantity: '100', unit: 'g' },
+      { name: 'Onion', quantity: '50', unit: 'g' },
+    ];
+    expect(rowsToIngredients(rows)).toHaveLength(1);
+    expect(rowsToIngredients(rows)[0].name).toBe('Onion');
+  });
+
+  it('filters out rows with zero or non-numeric quantity', () => {
+    const rows: IngRow[] = [
+      { name: 'Salt', quantity: '0', unit: 'tsp' },
+      { name: 'Pepper', quantity: '', unit: 'pinch' },
+      { name: 'Garlic', quantity: '2', unit: 'clove' },
+    ];
+    const result = rowsToIngredients(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Garlic');
+  });
+
+  it('trims whitespace from ingredient names', () => {
+    const rows: IngRow[] = [
+      { name: '  Tomato  ', quantity: '100', unit: 'g' },
+    ];
+    expect(rowsToIngredients(rows)[0].name).toBe('Tomato');
+  });
+});
+
+describe('ingredientsToRows', () => {
+  it('converts RecipeIngredients to row shape', () => {
+    const ingredients: Ingredient[] = [
+      { name: 'Jasmine rice', baseQuantity: 160, unit: 'g' },
+    ];
+    const rows = ingredientsToRows(ingredients);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('Jasmine rice');
+    expect(rows[0].quantity).toBe('160');
+    expect(rows[0].unit).toBe('g');
+  });
+
+  it('round-trips a set of ingredients through row ↔ ingredient conversion', () => {
+    const original: Ingredient[] = [
+      { name: 'Chicken breast', baseQuantity: 300, unit: 'g' },
+      { name: 'Jasmine rice', baseQuantity: 160, unit: 'g' },
+      { name: 'Olive oil', baseQuantity: 2, unit: 'tbsp' },
+    ];
+    const rows = ingredientsToRows(original);
+    const roundTripped = rowsToIngredients(rows);
+    expect(roundTripped).toHaveLength(original.length);
+    original.forEach((orig, i) => {
+      expect(roundTripped[i].name).toBe(orig.name);
+      expect(roundTripped[i].baseQuantity).toBe(orig.baseQuantity);
+      expect(roundTripped[i].unit).toBe(orig.unit);
+    });
+  });
+});

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -715,16 +715,19 @@ export async function getRecipeById(id: string): Promise<Recipe | null> {
   };
 }
 
+// ─── Private insert helper ────────────────────────────────────────────────────
+
 /**
- * Import a recipe into the library.  Uses INSERT OR IGNORE so calling it
- * twice with the same id is safe (duplicate guard returns false).
- *
- * @returns true when the recipe was newly inserted, false when it already existed.
+ * Shared INSERT helper used by both importRecipe and createRecipe.
+ * Callers choose the conflict strategy: IGNORE (import) or REPLACE (create).
  */
-export async function importRecipe(recipe: Recipe): Promise<boolean> {
-  const db = getDatabase();
-  const result = await db.runAsync(
-    `INSERT OR IGNORE INTO recipe_library
+async function _insertRecipe(
+  db: SQLite.SQLiteDatabase,
+  recipe: Recipe,
+  conflict: 'IGNORE' | 'REPLACE',
+): Promise<SQLite.SQLiteRunResult> {
+  return db.runAsync(
+    `INSERT OR ${conflict} INTO recipe_library
        (id, title, category, calories, protein, carbs, fat, prepTimeMinutes,
         defaultServings, ingredients, instructions, freezerTips)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -743,8 +746,98 @@ export async function importRecipe(recipe: Recipe): Promise<boolean> {
       recipe.freezerTips ?? '',
     ],
   );
+}
+
+/**
+ * Import a recipe into the library.  Uses INSERT OR IGNORE so calling it
+ * twice with the same id is safe (duplicate guard returns false).
+ *
+ * @returns true when the recipe was newly inserted, false when it already existed.
+ */
+export async function importRecipe(recipe: Recipe): Promise<boolean> {
+  const db = getDatabase();
+  const result = await _insertRecipe(db, recipe, 'IGNORE');
   // lastInsertRowId > 0 means a row was actually inserted
   return (result.changes ?? 0) > 0;
+}
+
+/**
+ * Returns true when the recipe id belongs to the 100 seeded ground-stock
+ * recipes (ids matching /^r\d{3}$/, i.e. r001–r100).  These recipes are
+ * protected from deletion — derive the guard from the id pattern so no
+ * schema migration or extra column is needed.
+ */
+export function isSeededRecipe(id: string): boolean {
+  return /^r\d{3}$/.test(id);
+}
+
+/**
+ * Insert a user-created recipe into recipe_library.
+ * Assigns a stable `custom-<timestamp>` id so the recipe participates in
+ * the shopping/cooking/meal-plan pipeline identically to seeded recipes.
+ * Caller should set recipe.id = `custom-${Date.now()}` before passing in,
+ * OR pass the recipe without an id and let this function generate one.
+ *
+ * If recipe.id is already set (e.g. to a custom-* value from a prior call),
+ * it is used as-is (INSERT OR REPLACE so re-saves are idempotent).
+ */
+export async function createRecipe(recipe: Recipe): Promise<void> {
+  const db = getDatabase();
+  const recipeWithId: Recipe = recipe.id
+    ? recipe
+    : { ...recipe, id: `custom-${Date.now()}` };
+  await _insertRecipe(db, recipeWithId, 'REPLACE');
+}
+
+/**
+ * Update an existing recipe_library row by id.
+ * All fields including recomputed macros and the ingredients JSON are replaced.
+ */
+export async function updateRecipe(recipe: Recipe): Promise<void> {
+  const db = getDatabase();
+  await db.runAsync(
+    `UPDATE recipe_library
+     SET title = ?, category = ?, calories = ?, protein = ?, carbs = ?, fat = ?,
+         prepTimeMinutes = ?, defaultServings = ?, ingredients = ?,
+         instructions = ?, freezerTips = ?
+     WHERE id = ?`,
+    [
+      recipe.title,
+      recipe.category,
+      recipe.calories,
+      recipe.protein,
+      recipe.carbs,
+      recipe.fat,
+      recipe.prepTimeMinutes,
+      recipe.defaultServings,
+      JSON.stringify(recipe.ingredients),
+      recipe.instructions,
+      recipe.freezerTips ?? '',
+      recipe.id,
+    ],
+  );
+}
+
+/**
+ * Delete a recipe from recipe_library by id.
+ * Callers should check isSeededRecipe(id) before calling this and refuse
+ * to delete protected seed recipes (r001–r100).
+ */
+export async function deleteRecipe(id: string): Promise<void> {
+  const db = getDatabase();
+  await db.runAsync('DELETE FROM recipe_library WHERE id = ?', [id]);
+}
+
+/**
+ * Return all distinct category strings present in recipe_library,
+ * sorted alphabetically.  Used by the editor to populate the category picker.
+ */
+export async function getRecipeCategories(): Promise<string[]> {
+  const db = getDatabase();
+  const rows = await db.getAllAsync<{ category: string }>(
+    'SELECT DISTINCT category FROM recipe_library ORDER BY category ASC',
+  );
+  return rows.map((r) => r.category);
 }
 
 // ─────────────────────────────────────────────

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -11,6 +11,7 @@ import MealPrepScreen from '../screens/MealPrepScreen';
 import TemplateEditorScreen from '../screens/TemplateEditorScreen';
 import RecipesScreen from '../screens/RecipesScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
+import RecipeEditorScreen from '../screens/RecipeEditorScreen';
 import DiscoverScreen from '../screens/DiscoverScreen';
 import DiscoverDetailScreen from '../screens/DiscoverDetailScreen';
 import ShoppingListScreen from '../screens/ShoppingListScreen';
@@ -27,6 +28,7 @@ function RecipesStackScreen() {
     <RecipeStack.Navigator screenOptions={{ headerShown: false }}>
       <RecipeStack.Screen name="RecipesMain" component={RecipesScreen} />
       <RecipeStack.Screen name="RecipeDetail" component={RecipeDetailScreen} />
+      <RecipeStack.Screen name="RecipeEditor" component={RecipeEditorScreen} />
     </RecipeStack.Navigator>
   );
 }

--- a/src/screens/RecipeDetailScreen.tsx
+++ b/src/screens/RecipeDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -9,8 +9,15 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
-import { getRecipeById, Recipe, addShoppingListItem, insertCookingTask } from '../db/database';
-import { useRoute, useNavigation } from '@react-navigation/native';
+import {
+  getRecipeById,
+  Recipe,
+  addShoppingListItem,
+  insertCookingTask,
+  deleteRecipe,
+  isSeededRecipe,
+} from '../db/database';
+import { useRoute, useNavigation, useFocusEffect } from '@react-navigation/native';
 import { Card, Row, IconChip, Button } from '../components';
 import { iconChipIconColor } from '../components/IconChip';
 
@@ -39,11 +46,14 @@ export default function RecipeDetailScreen() {
   const [recipe, setRecipe] = useState<Recipe | null>(null);
   const [servings, setServings] = useState<number>(1);
 
-  useEffect(() => {
-    if (recipeId) {
-      loadRecipe(recipeId);
-    }
-  }, [recipeId]);
+  // Reload recipe when the screen regains focus (e.g. returning from editor)
+  useFocusEffect(
+    useCallback(() => {
+      if (recipeId) {
+        loadRecipe(recipeId);
+      }
+    }, [recipeId]),
+  );
 
   const loadRecipe = async (id: string) => {
     const data = await getRecipeById(id);
@@ -51,6 +61,33 @@ export default function RecipeDetailScreen() {
       setRecipe(data);
       setServings(data.defaultServings);
     }
+  };
+
+  const handleEdit = () => {
+    navigation.navigate('RecipeEditor', { recipeId });
+  };
+
+  const handleDelete = () => {
+    if (!recipe) return;
+    Alert.alert(
+      'Delete Recipe',
+      `Are you sure you want to delete "${recipe.title}"? This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteRecipe(recipe.id);
+              navigation.navigate('RecipesMain');
+            } catch {
+              Alert.alert('Error', 'Failed to delete recipe.');
+            }
+          },
+        },
+      ],
+    );
   };
 
   const getCalculatedQuantity = (baseQuantity: number) => {
@@ -238,6 +275,29 @@ export default function RecipeDetailScreen() {
             variant="ghost"
             onPress={() => navigation.navigate('Cooking Tasks')}
           />
+
+          {/* Edit/Delete row — always show Edit; Delete only for non-seeded recipes */}
+          <View style={styles.editDeleteRow}>
+            <TouchableOpacity
+              style={styles.editBtn}
+              onPress={handleEdit}
+              activeOpacity={0.75}
+            >
+              <Ionicons name="create-outline" size={16} color={Colors.sageDeep} />
+              <Text style={styles.editBtnText}>Edit Recipe</Text>
+            </TouchableOpacity>
+
+            {!isSeededRecipe(recipe.id) && (
+              <TouchableOpacity
+                style={styles.deleteBtn}
+                onPress={handleDelete}
+                activeOpacity={0.75}
+              >
+                <Ionicons name="trash-outline" size={16} color={Colors.danger} />
+                <Text style={styles.deleteBtnText}>Delete</Text>
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
 
         <View style={{ height: Spacing.xxl }} />
@@ -464,5 +524,45 @@ const styles = StyleSheet.create({
   // ── Action buttons ────────────────────────────────────────────────────────
   actionsSection: {
     gap: Spacing.md,
+  },
+
+  // ── Edit / Delete row ─────────────────────────────────────────────────────
+  editDeleteRow: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+    justifyContent: 'center',
+    paddingTop: Spacing.xs,
+  },
+  editBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    borderRadius: Radius.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    backgroundColor: Colors.surface,
+  },
+  editBtnText: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.sageDeep,
+  },
+  deleteBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    borderRadius: Radius.md,
+    borderWidth: 1,
+    borderColor: Colors.danger,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    backgroundColor: Colors.surface,
+  },
+  deleteBtnText: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.danger,
   },
 });

--- a/src/screens/RecipeEditorScreen.tsx
+++ b/src/screens/RecipeEditorScreen.tsx
@@ -1,0 +1,989 @@
+/**
+ * RecipeEditorScreen.tsx
+ *
+ * Single screen for both CREATE and EDIT modes:
+ *   - No recipeId param  → create mode (empty form, custom-<timestamp> id)
+ *   - recipeId param     → edit mode (prefilled from recipe_library)
+ *
+ * Live macro preview is computed from the current ingredient list using
+ * the same engine as the import pipeline:
+ *   computeRecipeMacros() (local NUTRITION_TABLE) + lookupNutrition() (OFF).
+ *
+ * Styling: Verdure design system only — tokens from src/theme/tokens.ts.
+ * No raw hex, no magic numbers. Outline Ionicons only.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import {
+  createRecipe,
+  getRecipeById,
+  getRecipeCategories,
+  isSeededRecipe,
+  Recipe,
+  RecipeIngredient,
+  updateRecipe,
+} from '../db/database';
+import { computeRecipeMacros, ComputeIngredient } from '../nutrition/computeMacros';
+import { lookupNutrition } from '../api/openfoodfacts';
+import { normaliseIngredientName } from '../nutrition/units';
+import { NUTRITION_TABLE } from '../nutrition/nutritionTable';
+import { Card, Button, ScreenHeader } from '../components';
+import { Colors, Radius, Spacing, Typography } from '../theme/tokens';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Mutable row in the ingredient editor list. */
+interface IngredientRow {
+  key: string;        // local React key (UUID-ish)
+  name: string;
+  quantity: string;   // string so TextInput can show partial input
+  unit: string;
+}
+
+interface ComputedMacros {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const UNIT_OPTIONS = ['g', 'ml', 'whole', 'tsp', 'tbsp', 'cup', 'oz', 'clove', 'slice', 'pinch'];
+
+const KNOWN_CATEGORIES = [
+  'Fresh & Fridge',
+  'Quick Cook',
+  'Freezer Batch',
+  'Freezer Sauce',
+  'Imported',
+];
+
+const DEFAULT_SERVINGS = '4';
+const DEFAULT_PREP = '30';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let _rowCounter = 0;
+function newKey(): string {
+  return `row-${Date.now()}-${++_rowCounter}`;
+}
+
+function rowsToIngredients(rows: IngredientRow[]): RecipeIngredient[] {
+  return rows
+    .filter((r) => r.name.trim() !== '' && parseFloat(r.quantity) > 0)
+    .map((r) => ({
+      name: r.name.trim(),
+      baseQuantity: parseFloat(r.quantity) || 0,
+      unit: r.unit,
+    }));
+}
+
+function ingredientsToRows(ingredients: RecipeIngredient[]): IngredientRow[] {
+  return ingredients.map((ing) => ({
+    key: newKey(),
+    name: ing.name,
+    quantity: String(ing.baseQuantity),
+    unit: ing.unit,
+  }));
+}
+
+// ─── Main Screen ──────────────────────────────────────────────────────────────
+
+export default function RecipeEditorScreen() {
+  const route = useRoute<any>();
+  const navigation = useNavigation<any>();
+  const { recipeId } = route.params ?? {};
+  const isEdit = Boolean(recipeId);
+
+  // ── Form state ────────────────────────────────────────────────────────────
+  const [title, setTitle] = useState('');
+  const [category, setCategory] = useState('Fresh & Fridge');
+  const [customCategory, setCustomCategory] = useState('');
+  const [showCustomCategory, setShowCustomCategory] = useState(false);
+  const [servings, setServings] = useState(DEFAULT_SERVINGS);
+  const [prepTime, setPrepTime] = useState(DEFAULT_PREP);
+  const [ingredients, setIngredients] = useState<IngredientRow[]>([
+    { key: newKey(), name: '', quantity: '', unit: 'g' },
+  ]);
+  const [instructions, setInstructions] = useState('');
+  const [freezerTips, setFreezerTips] = useState('');
+
+  // ── Category picker state ─────────────────────────────────────────────────
+  const [categories, setCategories] = useState<string[]>(KNOWN_CATEGORIES);
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false);
+
+  // ── Macro preview state ───────────────────────────────────────────────────
+  const [macros, setMacros] = useState<ComputedMacros | null>(null);
+  const [macroLoading, setMacroLoading] = useState(false);
+  const [estimatedIngredients, setEstimatedIngredients] = useState<string[]>([]);
+
+  // ── Loading / saving state ────────────────────────────────────────────────
+  const [loading, setLoading] = useState(isEdit);
+  const [saving, setSaving] = useState(false);
+
+  // ── Refs ──────────────────────────────────────────────────────────────────
+  const recomputeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ── Load existing recipe in edit mode ────────────────────────────────────
+
+  useEffect(() => {
+    if (isEdit) {
+      loadRecipe();
+    }
+    loadCategories();
+  }, []);
+
+  const loadRecipe = async () => {
+    try {
+      const data = await getRecipeById(recipeId);
+      if (!data) {
+        Alert.alert('Error', 'Recipe not found.');
+        navigation.goBack();
+        return;
+      }
+      setTitle(data.title);
+      setServings(String(data.defaultServings));
+      setPrepTime(String(data.prepTimeMinutes));
+      setInstructions(data.instructions ?? '');
+      setFreezerTips(data.freezerTips ?? '');
+      setIngredients(
+        data.ingredients.length > 0
+          ? ingredientsToRows(data.ingredients)
+          : [{ key: newKey(), name: '', quantity: '', unit: 'g' }],
+      );
+
+      // Category
+      if (KNOWN_CATEGORIES.includes(data.category)) {
+        setCategory(data.category);
+        setShowCustomCategory(false);
+      } else {
+        setCategory('__custom__');
+        setCustomCategory(data.category);
+        setShowCustomCategory(true);
+      }
+    } catch {
+      Alert.alert('Error', 'Failed to load recipe.');
+      navigation.goBack();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadCategories = async () => {
+    try {
+      const dbCats = await getRecipeCategories();
+      // Merge with known categories, deduplicate, keep order
+      const merged = Array.from(new Set([...KNOWN_CATEGORIES, ...dbCats]));
+      setCategories(merged);
+    } catch {
+      // Non-fatal — use default list
+    }
+  };
+
+  // ── Live macro recompute ──────────────────────────────────────────────────
+
+  const scheduleMacroRecompute = useCallback(() => {
+    if (recomputeTimer.current) {
+      clearTimeout(recomputeTimer.current);
+    }
+    recomputeTimer.current = setTimeout(() => {
+      recomputeMacros();
+    }, 600);
+  }, [ingredients, servings]);
+
+  useEffect(() => {
+    scheduleMacroRecompute();
+    return () => {
+      if (recomputeTimer.current) clearTimeout(recomputeTimer.current);
+    };
+  }, [ingredients, servings]);
+
+  const recomputeMacros = async () => {
+    const validIngredients = rowsToIngredients(ingredients);
+    if (validIngredients.length === 0) {
+      setMacros(null);
+      setEstimatedIngredients([]);
+      return;
+    }
+
+    const numServings = Math.max(1, parseInt(servings, 10) || 1);
+
+    setMacroLoading(true);
+    try {
+      // Build OFF overrides for ingredients not in local table
+      const offOverrides: Record<string, { kcal: number; protein: number; carbs: number; fat: number }> = {};
+      const needsOFF = validIngredients.filter((ing) => {
+        const key = normaliseIngredientName(ing.name);
+        return !NUTRITION_TABLE[key];
+      });
+
+      for (const ing of needsOFF) {
+        try {
+          const nutrition = await lookupNutrition(ing.name);
+          if (nutrition) {
+            const key = normaliseIngredientName(ing.name);
+            offOverrides[key] = nutrition;
+            offOverrides[ing.name.toLowerCase()] = nutrition;
+          }
+        } catch {
+          // OFF call failed — ingredient will be estimated
+        }
+      }
+
+      const computeIngredients: ComputeIngredient[] = validIngredients.map((i) => ({
+        name: i.name,
+        baseQuantity: i.baseQuantity,
+        unit: i.unit,
+      }));
+
+      const result = computeRecipeMacros(
+        computeIngredients,
+        numServings,
+        Object.keys(offOverrides).length > 0 ? offOverrides : undefined,
+      );
+
+      setMacros(result.macros);
+      setEstimatedIngredients(result.unmatchedIngredients);
+    } catch {
+      // Leave previous macros displayed if recompute throws
+    } finally {
+      setMacroLoading(false);
+    }
+  };
+
+  // ── Ingredient list mutations ─────────────────────────────────────────────
+
+  const updateIngredient = (key: string, field: keyof IngredientRow, value: string) => {
+    setIngredients((prev) =>
+      prev.map((row) => (row.key === key ? { ...row, [field]: value } : row)),
+    );
+  };
+
+  const addIngredient = () => {
+    setIngredients((prev) => [...prev, { key: newKey(), name: '', quantity: '', unit: 'g' }]);
+  };
+
+  const removeIngredient = (key: string) => {
+    setIngredients((prev) => {
+      const next = prev.filter((r) => r.key !== key);
+      return next.length > 0 ? next : [{ key: newKey(), name: '', quantity: '', unit: 'g' }];
+    });
+  };
+
+  // ── Unit cycling (tap to cycle through options) ───────────────────────────
+
+  const cycleUnit = (key: string, currentUnit: string) => {
+    const idx = UNIT_OPTIONS.indexOf(currentUnit);
+    const next = UNIT_OPTIONS[(idx + 1) % UNIT_OPTIONS.length];
+    updateIngredient(key, 'unit', next);
+  };
+
+  // ── Save ──────────────────────────────────────────────────────────────────
+
+  const handleSave = async () => {
+    // Validation
+    if (!title.trim()) {
+      Alert.alert('Validation', 'Please enter a recipe title.');
+      return;
+    }
+
+    const validIngredients = rowsToIngredients(ingredients);
+    if (validIngredients.length === 0) {
+      Alert.alert('Validation', 'Please add at least one ingredient with a quantity.');
+      return;
+    }
+
+    const numServings = Math.max(1, parseInt(servings, 10) || 1);
+    const numPrepTime = Math.max(0, parseInt(prepTime, 10) || 0);
+
+    const resolvedCategory = showCustomCategory && customCategory.trim()
+      ? customCategory.trim()
+      : category;
+
+    // Compute final macros synchronously for the saved recipe
+    let finalMacros = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+    if (macros) {
+      finalMacros = macros;
+    } else {
+      const result = computeRecipeMacros(
+        validIngredients.map((i) => ({ name: i.name, baseQuantity: i.baseQuantity, unit: i.unit })),
+        numServings,
+      );
+      finalMacros = result.macros;
+    }
+
+    const recipe: Recipe = {
+      id: isEdit ? recipeId : `custom-${Date.now()}`,
+      title: title.trim(),
+      category: resolvedCategory,
+      calories: finalMacros.calories,
+      protein: finalMacros.protein,
+      carbs: finalMacros.carbs,
+      fat: finalMacros.fat,
+      prepTimeMinutes: numPrepTime,
+      defaultServings: numServings,
+      ingredients: validIngredients,
+      instructions: instructions.trim(),
+      freezerTips: freezerTips.trim(),
+    };
+
+    setSaving(true);
+    try {
+      if (isEdit) {
+        await updateRecipe(recipe);
+        navigation.goBack();
+      } else {
+        await createRecipe(recipe);
+        // Navigate to the new recipe's detail screen
+        navigation.replace('RecipeDetail', { recipeId: recipe.id });
+      }
+    } catch {
+      Alert.alert('Error', 'Failed to save recipe. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Loading state ─────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <View style={styles.centred}>
+        <ActivityIndicator size="large" color={Colors.sage} />
+      </View>
+    );
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const effectiveCategory = showCustomCategory ? '__custom__' : category;
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 88 : 0}
+    >
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        <ScreenHeader
+          title={isEdit ? 'Edit Recipe' : 'New Recipe'}
+          style={styles.header}
+        />
+
+        {/* ── Title ──────────────────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>TITLE</Text>
+          <Card style={styles.fieldCard}>
+            <TextInput
+              style={styles.textInput}
+              placeholder="Recipe name"
+              placeholderTextColor={Colors.textMuted}
+              value={title}
+              onChangeText={setTitle}
+              returnKeyType="next"
+              maxLength={120}
+            />
+          </Card>
+        </View>
+
+        {/* ── Category ───────────────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>CATEGORY</Text>
+          <Card style={styles.fieldCard}>
+            <TouchableOpacity
+              style={styles.pickerRow}
+              onPress={() => setShowCategoryPicker((v) => !v)}
+              activeOpacity={0.75}
+            >
+              <Text style={styles.pickerValue}>
+                {showCustomCategory
+                  ? (customCategory.trim() || 'Custom category')
+                  : category}
+              </Text>
+              <Ionicons
+                name={showCategoryPicker ? 'chevron-up-outline' : 'chevron-down-outline'}
+                size={16}
+                color={Colors.textMuted}
+              />
+            </TouchableOpacity>
+
+            {showCategoryPicker && (
+              <View style={styles.pickerOptions}>
+                {categories.map((cat) => (
+                  <TouchableOpacity
+                    key={cat}
+                    style={[
+                      styles.pickerOption,
+                      effectiveCategory === cat && styles.pickerOptionActive,
+                    ]}
+                    onPress={() => {
+                      setCategory(cat);
+                      setShowCustomCategory(false);
+                      setShowCategoryPicker(false);
+                    }}
+                    activeOpacity={0.75}
+                  >
+                    <Text
+                      style={[
+                        styles.pickerOptionText,
+                        effectiveCategory === cat && styles.pickerOptionTextActive,
+                      ]}
+                    >
+                      {cat}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+                {/* Custom entry */}
+                <TouchableOpacity
+                  style={[
+                    styles.pickerOption,
+                    showCustomCategory && styles.pickerOptionActive,
+                  ]}
+                  onPress={() => {
+                    setShowCustomCategory(true);
+                    setShowCategoryPicker(false);
+                  }}
+                  activeOpacity={0.75}
+                >
+                  <Text
+                    style={[
+                      styles.pickerOptionText,
+                      showCustomCategory && styles.pickerOptionTextActive,
+                    ]}
+                  >
+                    Custom...
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {showCustomCategory && (
+              <TextInput
+                style={[styles.textInput, styles.customCategoryInput]}
+                placeholder="Enter custom category"
+                placeholderTextColor={Colors.textMuted}
+                value={customCategory}
+                onChangeText={setCustomCategory}
+                returnKeyType="done"
+                maxLength={60}
+              />
+            )}
+          </Card>
+        </View>
+
+        {/* ── Servings + Prep Time ───────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>SERVINGS &amp; PREP TIME</Text>
+          <View style={styles.rowTwo}>
+            <Card style={[styles.fieldCard, styles.halfCard]}>
+              <Text style={styles.fieldLabel}>Default Servings</Text>
+              <TextInput
+                style={styles.numberInput}
+                placeholder="4"
+                placeholderTextColor={Colors.textMuted}
+                value={servings}
+                onChangeText={setServings}
+                keyboardType="numeric"
+                returnKeyType="next"
+                maxLength={3}
+              />
+            </Card>
+            <Card style={[styles.fieldCard, styles.halfCard]}>
+              <Text style={styles.fieldLabel}>Prep Time (min)</Text>
+              <TextInput
+                style={styles.numberInput}
+                placeholder="30"
+                placeholderTextColor={Colors.textMuted}
+                value={prepTime}
+                onChangeText={setPrepTime}
+                keyboardType="numeric"
+                returnKeyType="next"
+                maxLength={4}
+              />
+            </Card>
+          </View>
+        </View>
+
+        {/* ── Ingredients ───────────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>INGREDIENTS</Text>
+          <Card style={styles.ingredientsCard}>
+            {ingredients.map((row, idx) => (
+              <View key={row.key}>
+                {idx > 0 && <View style={styles.rowDivider} />}
+                <IngredientEditorRow
+                  row={row}
+                  onChangeName={(v) => updateIngredient(row.key, 'name', v)}
+                  onChangeQuantity={(v) => updateIngredient(row.key, 'quantity', v)}
+                  onCycleUnit={() => cycleUnit(row.key, row.unit)}
+                  onRemove={() => removeIngredient(row.key)}
+                  showRemove={ingredients.length > 1}
+                />
+              </View>
+            ))}
+
+            <TouchableOpacity
+              style={styles.addIngredientBtn}
+              onPress={addIngredient}
+              activeOpacity={0.75}
+            >
+              <Ionicons name="add-circle-outline" size={18} color={Colors.sage} />
+              <Text style={styles.addIngredientText}>Add ingredient</Text>
+            </TouchableOpacity>
+          </Card>
+        </View>
+
+        {/* ── Live Macro Preview ─────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>MACROS PER SERVING (ESTIMATED)</Text>
+          <Card style={styles.macroCard}>
+            {macroLoading ? (
+              <View style={styles.macroLoading}>
+                <ActivityIndicator size="small" color={Colors.sage} />
+                <Text style={styles.macroLoadingText}>Computing…</Text>
+              </View>
+            ) : macros ? (
+              <View style={styles.macroRow}>
+                <MacroChip value={String(macros.calories)} label="kcal" />
+                <View style={styles.macroDivider} />
+                <MacroChip value={`${macros.protein}g`} label="Protein" />
+                <View style={styles.macroDivider} />
+                <MacroChip value={`${macros.carbs}g`} label="Carbs" />
+                <View style={styles.macroDivider} />
+                <MacroChip value={`${macros.fat}g`} label="Fat" />
+              </View>
+            ) : (
+              <Text style={styles.macroEmpty}>
+                Add ingredients with quantities to see macros.
+              </Text>
+            )}
+            {estimatedIngredients.length > 0 && (
+              <View style={styles.estimatedBanner}>
+                <Ionicons name="information-circle-outline" size={14} color={Colors.goldDeep} />
+                <Text style={styles.estimatedText}>
+                  Estimated (no data):{' '}
+                  {estimatedIngredients.join(', ')}
+                </Text>
+              </View>
+            )}
+            <TouchableOpacity
+              style={styles.recomputeBtn}
+              onPress={recomputeMacros}
+              activeOpacity={0.75}
+            >
+              <Ionicons name="refresh-outline" size={14} color={Colors.sageDeep} />
+              <Text style={styles.recomputeText}>Recompute</Text>
+            </TouchableOpacity>
+          </Card>
+        </View>
+
+        {/* ── Instructions ──────────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>INSTRUCTIONS</Text>
+          <Card style={styles.fieldCard}>
+            <TextInput
+              style={[styles.textInput, styles.multilineInput]}
+              placeholder="Describe the cooking steps. Each new line becomes a numbered step."
+              placeholderTextColor={Colors.textMuted}
+              value={instructions}
+              onChangeText={setInstructions}
+              multiline
+              textAlignVertical="top"
+              returnKeyType="default"
+            />
+          </Card>
+        </View>
+
+        {/* ── Freezer Tips ──────────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>FREEZER TIPS (OPTIONAL)</Text>
+          <Card style={styles.fieldCard}>
+            <TextInput
+              style={[styles.textInput, styles.multilineInput]}
+              placeholder="Any notes for freezing and reheating"
+              placeholderTextColor={Colors.textMuted}
+              value={freezerTips}
+              onChangeText={setFreezerTips}
+              multiline
+              textAlignVertical="top"
+              returnKeyType="default"
+            />
+          </Card>
+        </View>
+
+        {/* ── Save button ────────────────────────────────────────────────── */}
+        <View style={styles.actionsSection}>
+          <Button
+            title={saving ? 'Saving…' : isEdit ? 'Save Changes' : 'Create Recipe'}
+            variant="primary"
+            onPress={handleSave}
+            disabled={saving}
+          />
+          <Button
+            title="Cancel"
+            variant="ghost"
+            onPress={() => navigation.goBack()}
+            disabled={saving}
+          />
+        </View>
+
+        <View style={{ height: Spacing.xxl }} />
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface IngredientEditorRowProps {
+  row: IngredientRow;
+  onChangeName: (v: string) => void;
+  onChangeQuantity: (v: string) => void;
+  onCycleUnit: () => void;
+  onRemove: () => void;
+  showRemove: boolean;
+}
+
+function IngredientEditorRow({
+  row,
+  onChangeName,
+  onChangeQuantity,
+  onCycleUnit,
+  onRemove,
+  showRemove,
+}: IngredientEditorRowProps) {
+  return (
+    <View style={styles.ingredientRow}>
+      {/* Name */}
+      <TextInput
+        style={[styles.textInput, styles.ingredientName]}
+        placeholder="Ingredient name"
+        placeholderTextColor={Colors.textMuted}
+        value={row.name}
+        onChangeText={onChangeName}
+        returnKeyType="next"
+      />
+      {/* Quantity */}
+      <TextInput
+        style={[styles.textInput, styles.ingredientQty]}
+        placeholder="Qty"
+        placeholderTextColor={Colors.textMuted}
+        value={row.quantity}
+        onChangeText={onChangeQuantity}
+        keyboardType="decimal-pad"
+        returnKeyType="next"
+      />
+      {/* Unit — tap to cycle */}
+      <TouchableOpacity
+        style={styles.unitChip}
+        onPress={onCycleUnit}
+        activeOpacity={0.75}
+        hitSlop={{ top: 4, bottom: 4, left: 4, right: 4 }}
+      >
+        <Text style={styles.unitChipText}>{row.unit}</Text>
+      </TouchableOpacity>
+      {/* Remove */}
+      {showRemove && (
+        <TouchableOpacity
+          onPress={onRemove}
+          activeOpacity={0.75}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          <Ionicons name="close-circle-outline" size={20} color={Colors.textMuted} />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+interface MacroChipProps {
+  value: string;
+  label: string;
+}
+
+function MacroChip({ value, label }: MacroChipProps) {
+  return (
+    <View style={styles.macroChip}>
+      <Text style={styles.macroValue}>{value}</Text>
+      <Text style={styles.macroLabel}>{label}</Text>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  scrollContent: {
+    paddingBottom: Spacing.xxl,
+  },
+  centred: {
+    flex: 1,
+    backgroundColor: Colors.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // ── Header ────────────────────────────────────────────────────────────────
+  header: {
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.sm,
+  },
+
+  // ── Section ───────────────────────────────────────────────────────────────
+  section: {
+    paddingHorizontal: Spacing.lg,
+    marginBottom: Spacing.xl,
+  },
+  sectionLabel: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 1.2,
+    marginBottom: Spacing.sm,
+  },
+
+  // ── Cards & inputs ────────────────────────────────────────────────────────
+  fieldCard: {
+    padding: Spacing.md,
+  },
+  halfCard: {
+    flex: 1,
+  },
+  rowTwo: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+  },
+  fieldLabel: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs - 1,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginBottom: Spacing.xs,
+  },
+  textInput: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+    paddingVertical: Spacing.xs,
+  },
+  numberInput: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.xl,
+    color: Colors.textPrimary,
+    letterSpacing: -0.4,
+    paddingVertical: Spacing.xs,
+  },
+  multilineInput: {
+    minHeight: 100,
+    lineHeight: Typography.sizes.sm * 1.55,
+  },
+
+  // ── Category picker ───────────────────────────────────────────────────────
+  pickerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: Spacing.xs,
+  },
+  pickerValue: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+    flex: 1,
+  },
+  pickerOptions: {
+    marginTop: Spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    paddingTop: Spacing.sm,
+    gap: Spacing.xs,
+  },
+  pickerOption: {
+    borderRadius: Radius.sm,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+  },
+  pickerOptionActive: {
+    backgroundColor: Colors.sageTint,
+  },
+  pickerOptionText: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textSecondary,
+  },
+  pickerOptionTextActive: {
+    color: Colors.sageDeep,
+    fontFamily: Typography.title,
+  },
+  customCategoryInput: {
+    marginTop: Spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    paddingTop: Spacing.sm,
+  },
+
+  // ── Ingredients ───────────────────────────────────────────────────────────
+  ingredientsCard: {
+    padding: Spacing.md,
+    gap: 0,
+  },
+  ingredientRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingVertical: Spacing.sm,
+  },
+  ingredientName: {
+    flex: 1,
+  },
+  ingredientQty: {
+    width: 56,
+    textAlign: 'right',
+  },
+  unitChip: {
+    backgroundColor: Colors.sageTint,
+    borderRadius: Radius.sm,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xs,
+    minWidth: 44,
+    alignItems: 'center',
+  },
+  unitChipText: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    color: Colors.sageDeep,
+    letterSpacing: 0.4,
+  },
+  rowDivider: {
+    height: 1,
+    backgroundColor: Colors.border,
+    marginHorizontal: 0,
+  },
+  addIngredientBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    paddingTop: Spacing.md,
+    marginTop: Spacing.xs,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  addIngredientText: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.sage,
+  },
+
+  // ── Macro preview ─────────────────────────────────────────────────────────
+  macroCard: {
+    padding: Spacing.lg,
+    gap: Spacing.sm,
+  },
+  macroLoading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingVertical: Spacing.sm,
+  },
+  macroLoadingText: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textMuted,
+  },
+  macroRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  macroChip: {
+    flex: 1,
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
+  macroValue: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.md,
+    color: Colors.clayDeep,
+    letterSpacing: -0.3,
+  },
+  macroLabel: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs - 1,
+    color: Colors.clay,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  macroDivider: {
+    width: 1,
+    height: 28,
+    backgroundColor: Colors.border,
+  },
+  macroEmpty: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: Spacing.sm,
+  },
+  estimatedBanner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Spacing.xs,
+    backgroundColor: Colors.goldTint,
+    borderRadius: Radius.sm,
+    padding: Spacing.sm,
+  },
+  estimatedText: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.goldDeep,
+    flex: 1,
+    lineHeight: Typography.sizes.xs * 1.5,
+  },
+  recomputeBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    alignSelf: 'flex-end',
+  },
+  recomputeText: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    color: Colors.sageDeep,
+    letterSpacing: 0.4,
+  },
+
+  // ── Actions ───────────────────────────────────────────────────────────────
+  actionsSection: {
+    paddingHorizontal: Spacing.lg,
+    gap: Spacing.md,
+  },
+});

--- a/src/screens/RecipesScreen.tsx
+++ b/src/screens/RecipesScreen.tsx
@@ -138,11 +138,22 @@ export default function RecipesScreen() {
 
   return (
     <View style={styles.container}>
-      {/* Screen header — Fraunces display title */}
+      {/* Screen header — Fraunces display title + New Recipe action */}
       <ScreenHeader
         title="Recipe Library"
         subtitle={`${filteredRecipes.length} recipe${filteredRecipes.length === 1 ? '' : 's'}`}
         style={styles.screenHeader}
+        trailing={
+          <TouchableOpacity
+            style={styles.newRecipeBtn}
+            onPress={() => navigation.navigate('RecipeEditor')}
+            activeOpacity={0.75}
+            accessibilityLabel="Create new recipe"
+            accessibilityRole="button"
+          >
+            <Ionicons name="add-outline" size={20} color={Colors.surface} />
+          </TouchableOpacity>
+        }
       />
 
       {/* Search bar */}
@@ -217,6 +228,14 @@ const styles = StyleSheet.create({
   screenHeader: {
     paddingTop: Spacing.sm,
     paddingBottom: Spacing.sm,
+  },
+  newRecipeBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: Radius.full,
+    backgroundColor: Colors.sage,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 
   // ── Search bar ────────────────────────────────────────────────────────────

--- a/src/screens/__tests__/RecipeEditorScreen.test.tsx
+++ b/src/screens/__tests__/RecipeEditorScreen.test.tsx
@@ -1,0 +1,7 @@
+import RecipeEditorScreen from '../RecipeEditorScreen';
+
+describe('RecipeEditorScreen', () => {
+  it('is a valid React component', () => {
+    expect(typeof RecipeEditorScreen).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Full create / edit / delete capability for recipes, with macros computed live using the existing nutrition engine (local NUTRITION_TABLE + Open Food Facts fallback).

### DB layer (`database.ts`)
- **`createRecipe(recipe)`** — inserts with a `custom-<timestamp>` id via a shared private `_insertRecipe` helper (INSERT OR REPLACE).
- **`updateRecipe(recipe)`** — UPDATE all fields by id, including recomputed macros and ingredients JSON.
- **`deleteRecipe(id)`** — DELETE by id.
- **`isSeededRecipe(id)`** — returns `true` for ids matching `/^r\d{3}$/` (r001–r100). No migration needed — derived from the id pattern at runtime.
- **`getRecipeCategories()`** — DISTINCT category query used by the editor picker.
- `importRecipe` unchanged; it now delegates to `_insertRecipe` internally.

### `RecipeEditorScreen` (`src/screens/RecipeEditorScreen.tsx`)
- Create mode: opened without a `recipeId` param; saves with `createRecipe`, then navigates to the new recipe's detail screen.
- Edit mode: opened with a `recipeId` param; prefills from DB, saves with `updateRecipe`, then returns to detail.
- Fields: title, category picker (existing categories from DB + custom entry), default servings, prep time, ingredient rows (name / qty / unit — tap unit chip to cycle through g/ml/whole/tsp/tbsp/cup/oz/clove/slice/pinch), instructions (multiline), freezer tips (optional).
- **Live macro preview**: debounced recompute on ingredient/servings change. Calls `computeRecipeMacros` + `lookupNutrition` (OFF) for ingredients not in the local table. Offline-safe (try/catch around each OFF call). Unresolved ingredients surfaced in a gold "Estimated" banner. Manual "Recompute" affordance available.
- Validation: title required, at least one ingredient with a quantity, servings ≥ 1.

### Entry points
- **`RecipesScreen`** — circular sage FAB in the `ScreenHeader` trailing slot navigates to `RecipeEditor` (create mode).
- **`RecipeDetailScreen`** — `useFocusEffect` reload after returning from editor. "Edit Recipe" button always shown. "Delete" button shown **only for non-seeded recipes** (`custom-*` / `mealdb-*`); asks for confirmation before calling `deleteRecipe`, then navigates back to the recipes list.

### Navigation
- `RecipeEditor` registered as a third screen in the Recipes stack: `RecipesMain` → `RecipeDetail` → `RecipeEditor`.

### How macro recompute reuses the import pipeline
`computeRecipeMacros` (from `src/nutrition/computeMacros.ts`) is called directly with the current ingredient list. For ingredients not in the local `NUTRITION_TABLE`, `lookupNutrition` (from `src/api/openfoodfacts.ts`) is called — the same path used by `buildImportResult` in `src/nutrition/importRecipe.ts`. No Atwater math or OFF logic is duplicated.

### Delete-protection
`isSeededRecipe(id)` returns `true` for IDs matching `/^r\d{3}$/`. The 100 seeded recipes have IDs `r001`–`r100`. User-created (`custom-*`) and imported (`mealdb-*`) recipes return `false` and are deletable. The guard is derived from the ID pattern at runtime — no schema column or migration needed.

### Constraints
- No new npm dependencies (RN primitives + shared Verdure kit only).
- No schema migration.
- Keyless — no build gate, JS/TS-only change.

### Quality gates
- `npm run typecheck` — passes (exit 0).
- `npm test` — 9 suites, 105 tests, all green. New tests: `RecipeEditorScreen.test.tsx` (smoke), `recipeHelpers.test.ts` (isSeededRecipe, rowsToIngredients, round-trip).

Closes #263