### PR TITLE
Analytics · strength progression + longer trends & streaks

### DIFF
--- a/src/screens/AnalyticsDashboardScreen.tsx
+++ b/src/screens/AnalyticsDashboardScreen.tsx
@@ -2,6 +2,7 @@
  * AnalyticsDashboardScreen
  *
  * Verdure redesign: Unit 10 (#245)
+ * Extended with strength progression + longer trends & streaks: #265
  *
  * Behaviour-preserving restyle only. All DB queries and metric calculations
  * are unchanged. Presentation updated to the Verdure calm-wellness system
@@ -11,7 +12,10 @@
  *   - ScreenHeader (Fraunces title, "Last 30 days" subtitle)
  *   - Metric cards row: Weight delta | Workout count | Fasting streak
  *   - Weight trend card: flat View-based chart (sage line, sageTint area, sageDeep dot)
- *   - Consistency grid: 7-col rounded dot grid (sage/gold/canvasSunken) + legend
+ *                        with 30/90-day Pill toggle
+ *   - Strength progression chart: step-line of gym weight over 90 days
+ *   - Streaks card: current + longest for gym, walk, fasting
+ *   - Consistency grid: 7-col rounded dot grid (sage/gold/canvasSunken) 30-day + legend
  *   - 7-day / 30-day rolling stats with ProgressBar rows
  */
 import React, { useState, useCallback } from 'react';
@@ -21,11 +25,24 @@ import {
   StyleSheet,
   ScrollView,
   RefreshControl,
+  TouchableOpacity,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
-import { getRollingWindow, getWeightHistory, toISODate } from '../db/database';
+import {
+  getRollingWindow,
+  getWeightHistory,
+  getStartDate,
+  toISODate,
+} from '../db/database';
 import { Card, ProgressBar, ScreenHeader, Pill } from '../components';
+import {
+  computeStreaks,
+  computeStrengthProgression,
+  progressionSteps,
+  StreakSet,
+  KG_PER_CYCLE,
+} from './analyticsHelpers';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -38,6 +55,7 @@ interface RollingStats {
 }
 
 type DotState = 'complete' | 'partial' | 'missed';
+type WeightWindow = 30 | 90;
 
 // ─── Metric card ──────────────────────────────────────────────────────────────
 
@@ -59,14 +77,19 @@ function MetricCard({
   );
 }
 
-// ─── Weight trend (flat View-based chart recoloured to Verdure) ───────────────
+// ─── Weight trend (flat View-based chart with 30/90-day toggle) ───────────────
 
 function WeightTrendCard({
-  history,
+  history30,
+  history90,
 }: {
-  history: { date: string; weight: number }[];
+  history30: { date: string; weight: number }[];
+  history90: { date: string; weight: number }[];
 }) {
-  if (history.length === 0) {
+  const [window, setWindow] = useState<WeightWindow>(30);
+  const history = window === 30 ? history30 : history90;
+
+  if (history30.length === 0 && history90.length === 0) {
     return (
       <Card style={styles.sectionCard}>
         <View style={styles.cardTitleRow}>
@@ -77,70 +100,304 @@ function WeightTrendCard({
     );
   }
 
-  const weights = history.map((w) => w.weight);
+  const weights = history.length > 0 ? history.map((w) => w.weight) : [0];
   const minW = Math.min(...weights) - 2;
   const maxW = Math.max(...weights) + 2;
-  const current = weights[weights.length - 1];
-  const range = maxW - minW;
+  const current = history.length > 0 ? weights[weights.length - 1] : null;
+  const range = maxW - minW || 1;
 
   return (
     <Card style={styles.sectionCard}>
       <View style={styles.cardTitleRow}>
         <Text style={styles.cardSectionTitle}>Body weight</Text>
-        <Text style={styles.currentWeightLabel}>{current.toFixed(1)} kg</Text>
+        {current !== null && (
+          <Text style={styles.currentWeightLabel}>{current.toFixed(1)} kg</Text>
+        )}
       </View>
 
-      {/* Flat chart: sage-tint area fill + sage bars + sageDeep dot on last point.
-          Uses View-based rendering (no new chart dependency) per DESIGN.md §5. */}
-      <View style={styles.chartContainer}>
-        {/* sageTint area spans the full chart width at half-opacity */}
-        <View style={styles.areaBackground} />
+      {/* 30/90 day toggle */}
+      <View style={styles.toggleRow}>
+        <TouchableOpacity
+          onPress={() => setWindow(30)}
+          style={[
+            styles.togglePill,
+            window === 30 && styles.togglePillActive,
+          ]}
+        >
+          <Text
+            style={[
+              styles.togglePillText,
+              window === 30 && styles.togglePillTextActive,
+            ]}
+          >
+            30d
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() => setWindow(90)}
+          style={[
+            styles.togglePill,
+            window === 90 && styles.togglePillActive,
+          ]}
+        >
+          <Text
+            style={[
+              styles.togglePillText,
+              window === 90 && styles.togglePillTextActive,
+            ]}
+          >
+            90d
+          </Text>
+        </TouchableOpacity>
+      </View>
 
-        {/* Bars + last-point dot */}
-        <View style={styles.lineLayer}>
-          {history.map((pt, i) => {
-            const heightPct = Math.max(4, ((pt.weight - minW) / range) * 100);
-            const isLast = i === history.length - 1;
-            return (
-              <View key={`bar-${i}`} style={styles.barColumn}>
-                {isLast ? (
-                  /* sageDeep dot for the most-recent data point */
-                  <View style={styles.lastDot} />
-                ) : (
-                  <View
-                    style={[
-                      styles.bar,
-                      {
-                        height: `${heightPct}%`,
-                        backgroundColor: Colors.sage,
-                      },
-                    ]}
-                  />
-                )}
-                {(i === 0 || isLast) && (
-                  <Text style={styles.barDateLabel}>
-                    {pt.date.substring(8, 10)}/{pt.date.substring(5, 7)}
-                  </Text>
-                )}
-              </View>
-            );
-          })}
+      {history.length === 0 ? (
+        <Text style={styles.emptyText}>No data for this period.</Text>
+      ) : (
+        <>
+          {/* Flat chart: sage-tint area fill + sage bars + sageDeep dot on last point.
+              Uses View-based rendering (no new chart dependency) per DESIGN.md §5. */}
+          <View style={styles.chartContainer}>
+            {/* sageTint area spans the full chart width at half-opacity */}
+            <View style={styles.areaBackground} />
+
+            {/* Bars + last-point dot */}
+            <View style={styles.lineLayer}>
+              {history.map((pt, i) => {
+                const heightPct = Math.max(4, ((pt.weight - minW) / range) * 100);
+                const isLast = i === history.length - 1;
+                return (
+                  <View key={`bar-${i}`} style={styles.barColumn}>
+                    {isLast ? (
+                      /* sageDeep dot for the most-recent data point */
+                      <View style={styles.lastDot} />
+                    ) : (
+                      <View
+                        style={[
+                          styles.bar,
+                          {
+                            height: `${heightPct}%`,
+                            backgroundColor: Colors.sage,
+                          },
+                        ]}
+                      />
+                    )}
+                    {(i === 0 || isLast) && (
+                      <Text style={styles.barDateLabel}>
+                        {pt.date.substring(8, 10)}/{pt.date.substring(5, 7)}
+                      </Text>
+                    )}
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+
+          <View style={styles.chartMeta}>
+            <Text style={styles.chartMetaText}>
+              Min {(minW + 2).toFixed(1)} kg
+            </Text>
+            <Text style={styles.chartMetaText}>
+              Max {(maxW - 2).toFixed(1)} kg
+            </Text>
+          </View>
+        </>
+      )}
+    </Card>
+  );
+}
+
+// ─── Strength progression chart ───────────────────────────────────────────────
+
+interface StrengthProgressionCardProps {
+  startDateISO: string;
+  todayISO: string;
+}
+
+function StrengthProgressionCard({
+  startDateISO,
+  todayISO,
+}: StrengthProgressionCardProps) {
+  // Compute the 90-day window (or since start, whichever is shorter)
+  const windowStart = (() => {
+    const d = new Date(todayISO);
+    d.setDate(d.getDate() - 89);
+    const cutoff = toISODate(d);
+    return cutoff > startDateISO ? cutoff : startDateISO;
+  })();
+
+  const fullPoints = computeStrengthProgression(windowStart, todayISO, 0);
+  const steps = progressionSteps(fullPoints);
+
+  // Current weight and cycle
+  const lastPoint = fullPoints.length > 0 ? fullPoints[fullPoints.length - 1] : null;
+  const currentCycle = lastPoint?.cycle ?? 0;
+  const currentWeightAdded = lastPoint?.weightKg ?? 0;
+
+  // Too early — first cycle not even started yet
+  const isEarlyState = fullPoints.length > 0 && currentCycle === 0 && fullPoints.length < 7;
+
+  if (fullPoints.length === 0) {
+    return (
+      <Card style={styles.sectionCard}>
+        <View style={styles.cardTitleRow}>
+          <Text style={styles.cardSectionTitle}>Strength progression</Text>
+        </View>
+        <Text style={styles.emptyText}>
+          Start your first session to begin tracking progression.
+        </Text>
+      </Card>
+    );
+  }
+
+  const subtitleLabel =
+    currentCycle === 0
+      ? 'Baseline — first cycle in progress'
+      : `Cycle ${currentCycle} · +${currentWeightAdded}kg added`;
+
+  // Chart sizing
+  const maxWeight = steps.length > 0 ? Math.max(...steps.map((s) => s.weightKg)) : 0;
+  const chartMax = Math.max(maxWeight + KG_PER_CYCLE, KG_PER_CYCLE);
+
+  return (
+    <Card style={styles.sectionCard}>
+      <View style={styles.cardTitleRow}>
+        <Text style={styles.cardSectionTitle}>Strength progression</Text>
+        <Text style={styles.cardSectionTrailing}>{subtitleLabel}</Text>
+      </View>
+
+      {isEarlyState ? (
+        <Text style={styles.emptyText}>
+          Progression builds over your first cycle (21 days).
+        </Text>
+      ) : (
+        <>
+          {/* Step-line chart rendered as View-based bars.
+              Each step segment spans from its start date to the next step.
+              We render one bar per step point, width proportional to duration. */}
+          <View style={styles.strengthChartContainer}>
+            <View style={styles.areaBackground} />
+            <View style={styles.lineLayer}>
+              {steps.map((pt, i) => {
+                const heightPct = Math.max(
+                  6,
+                  chartMax > 0 ? ((pt.weightKg) / chartMax) * 100 : 6
+                );
+                const isLast = i === steps.length - 1;
+                return (
+                  <View key={`step-${i}`} style={styles.barColumn}>
+                    {isLast ? (
+                      <View
+                        style={[
+                          styles.strengthLastDot,
+                          {
+                            marginBottom:
+                              `${heightPct}%` as unknown as number,
+                          },
+                        ]}
+                      />
+                    ) : null}
+                    <View
+                      style={[
+                        styles.bar,
+                        {
+                          height: `${heightPct}%`,
+                          backgroundColor: isLast
+                            ? Colors.sageDeep
+                            : Colors.sage,
+                        },
+                      ]}
+                    />
+                    {(i === 0 || isLast) && (
+                      <Text style={styles.barDateLabel}>
+                        {pt.date.substring(8, 10)}/{pt.date.substring(5, 7)}
+                      </Text>
+                    )}
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+
+          {/* Cycle labels */}
+          <View style={styles.chartMeta}>
+            <Text style={styles.chartMetaText}>Baseline</Text>
+            {currentCycle > 0 && (
+              <Text style={[styles.chartMetaText, { color: Colors.sageDeep }]}>
+                +{currentWeightAdded}kg now
+              </Text>
+            )}
+          </View>
+        </>
+      )}
+    </Card>
+  );
+}
+
+// ─── Streaks card ─────────────────────────────────────────────────────────────
+
+function StreaksCard({ streaks }: { streaks: StreakSet }) {
+  return (
+    <Card style={styles.sectionCard}>
+      <Text style={styles.cardSectionTitle}>Streaks</Text>
+
+      {/* Column headers */}
+      <View style={[styles.streakRow, styles.streakHeaderRow]}>
+        <Text style={[styles.streakLabel, styles.streakHeaderText]} />
+        <Text style={[styles.streakValueLabel, styles.streakHeaderText]}>
+          Current
+        </Text>
+        <Text style={[styles.streakValueLabel, styles.streakHeaderText]}>
+          Best
+        </Text>
+      </View>
+
+      {/* Gym */}
+      <View style={styles.streakRow}>
+        <Text style={styles.streakLabel}>Gym</Text>
+        <View style={styles.streakValueCell}>
+          <Pill
+            label={`${streaks.gym.current}d`}
+            accent={streaks.gym.current > 0 ? 'sage' : 'gold'}
+          />
+        </View>
+        <View style={styles.streakValueCell}>
+          <Pill label={`${streaks.gym.longest}d`} accent="sage" />
         </View>
       </View>
 
-      <View style={styles.chartMeta}>
-        <Text style={styles.chartMetaText}>
-          Min {(minW + 2).toFixed(1)} kg
-        </Text>
-        <Text style={styles.chartMetaText}>
-          Max {(maxW - 2).toFixed(1)} kg
-        </Text>
+      {/* Walking */}
+      <View style={styles.streakRow}>
+        <Text style={styles.streakLabel}>Walking</Text>
+        <View style={styles.streakValueCell}>
+          <Pill
+            label={`${streaks.walk.current}d`}
+            accent={streaks.walk.current > 0 ? 'sage' : 'gold'}
+          />
+        </View>
+        <View style={styles.streakValueCell}>
+          <Pill label={`${streaks.walk.longest}d`} accent="sage" />
+        </View>
+      </View>
+
+      {/* Fasting */}
+      <View style={[styles.streakRow, { marginBottom: 0 }]}>
+        <Text style={styles.streakLabel}>Fasting</Text>
+        <View style={styles.streakValueCell}>
+          <Pill
+            label={`${streaks.fasting.current}d`}
+            accent={streaks.fasting.current > 0 ? 'sky' : 'gold'}
+          />
+        </View>
+        <View style={styles.streakValueCell}>
+          <Pill label={`${streaks.fasting.longest}d`} accent="sky" />
+        </View>
       </View>
     </Card>
   );
 }
 
-// ─── Consistency dot grid ─────────────────────────────────────────────────────
+// ─── Consistency dot grid (30-day) ────────────────────────────────────────────
 
 function ConsistencyGrid({ dots }: { dots: DotState[] }) {
   const DOT_COLORS: Record<DotState, string> = {
@@ -153,7 +410,7 @@ function ConsistencyGrid({ dots }: { dots: DotState[] }) {
     <Card style={styles.sectionCard}>
       <View style={styles.cardTitleRow}>
         <Text style={styles.cardSectionTitle}>Consistency</Text>
-        <Text style={styles.cardSectionTrailing}>Last 14 days</Text>
+        <Text style={styles.cardSectionTrailing}>Last 30 days</Text>
       </View>
 
       <View style={styles.dotGrid}>
@@ -252,8 +509,16 @@ export default function AnalyticsDashboardScreen() {
   const [stats30Day, setStats30Day] = useState<RollingStats>({
     walk: 0, gym: 0, extra: 0, total: 0, fasting: 0,
   });
-  const [weightHistory, setWeightHistory] = useState<{ date: string; weight: number }[]>([]);
+  const [weightHistory30, setWeightHistory30] = useState<{ date: string; weight: number }[]>([]);
+  const [weightHistory90, setWeightHistory90] = useState<{ date: string; weight: number }[]>([]);
   const [consistencyDots, setConsistencyDots] = useState<DotState[]>([]);
+  const [startDateISO, setStartDateISO] = useState<string>('');
+  const [todayISO, setTodayISO] = useState<string>('');
+  const [streaks, setStreaks] = useState<StreakSet>({
+    gym: { current: 0, longest: 0 },
+    walk: { current: 0, longest: 0 },
+    fasting: { current: 0, longest: 0 },
+  });
 
   // Metrics derived from 30-day window
   const [weightDelta, setWeightDelta] = useState<number | null>(null);
@@ -264,19 +529,24 @@ export default function AnalyticsDashboardScreen() {
     setLoading(true);
     try {
       const logs = await getRollingWindow();
-      const weightData = await getWeightHistory(30);
+      const weightData30 = await getWeightHistory(30);
+      const weightData90 = await getWeightHistory(90);
+      const startDate = await getStartDate();
 
       const today = new Date();
       today.setHours(0, 0, 0, 0);
+      const todayStr = toISODate(today);
+
+      setStartDateISO(startDate);
+      setTodayISO(todayStr);
 
       const computeStats = (days: number): RollingStats => {
         const cutoff = new Date(today);
         cutoff.setDate(cutoff.getDate() - days);
         const cutoffIso = toISODate(cutoff);
-        const todayIso = toISODate(today);
 
         const relevant = logs.filter(
-          (l) => l.date >= cutoffIso && l.date <= todayIso
+          (l) => l.date >= cutoffIso && l.date <= todayStr
         );
         const total = relevant.length;
         if (total === 0) return { walk: 0, gym: 0, extra: 0, total: 0, fasting: 0 };
@@ -303,13 +573,14 @@ export default function AnalyticsDashboardScreen() {
       const s30 = computeStats(30);
       setStats7Day(s7);
       setStats30Day(s30);
-      setWeightHistory(weightData);
+      setWeightHistory30(weightData30);
+      setWeightHistory90(weightData90);
 
       // ── Metric card values ──────────────────────────────────────────────────
 
       // Weight delta (first vs last in 30-day window)
-      if (weightData.length >= 2) {
-        const delta = weightData[weightData.length - 1].weight - weightData[0].weight;
+      if (weightData30.length >= 2) {
+        const delta = weightData30[weightData30.length - 1].weight - weightData30[0].weight;
         setWeightDelta(delta);
       } else {
         setWeightDelta(null);
@@ -320,9 +591,8 @@ export default function AnalyticsDashboardScreen() {
       setWorkoutCount30(gymDays30 + s30.extra);
 
       // Fasting streak — consecutive days from today going back
-      const todayIso = toISODate(today);
       const sortedDesc = [...logs]
-        .filter((l) => l.date <= todayIso)
+        .filter((l) => l.date <= todayStr)
         .sort((a, b) => (a.date > b.date ? -1 : 1));
       let streak = 0;
       for (const l of sortedDesc) {
@@ -331,9 +601,13 @@ export default function AnalyticsDashboardScreen() {
       }
       setFastingStreak(streak);
 
-      // ── Consistency dots (last 14 days) ────────────────────────────────────
+      // ── Streaks (gym, walk, fasting) ────────────────────────────────────────
+      const computedStreaks = computeStreaks(logs, todayStr);
+      setStreaks(computedStreaks);
+
+      // ── Consistency dots (last 30 days) ────────────────────────────────────
       const dots: DotState[] = [];
-      for (let i = 13; i >= 0; i--) {
+      for (let i = 29; i >= 0; i--) {
         const d = new Date(today);
         d.setDate(d.getDate() - i);
         const iso = toISODate(d);
@@ -341,10 +615,8 @@ export default function AnalyticsDashboardScreen() {
         if (!log) {
           dots.push('missed');
         } else {
-          const allComplete =
-            log.walk_completed && log.hammer_completed;
-          const anyComplete =
-            log.walk_completed || log.hammer_completed;
+          const allComplete = log.walk_completed && log.hammer_completed;
+          const anyComplete = log.walk_completed || log.hammer_completed;
           if (allComplete) dots.push('complete');
           else if (anyComplete) dots.push('partial');
           else dots.push('missed');
@@ -405,10 +677,24 @@ export default function AnalyticsDashboardScreen() {
           />
         </View>
 
-        {/* Weight trend */}
-        <WeightTrendCard history={weightHistory} />
+        {/* Weight trend (30/90-day toggle) */}
+        <WeightTrendCard
+          history30={weightHistory30}
+          history90={weightHistory90}
+        />
 
-        {/* Consistency grid */}
+        {/* Strength progression */}
+        {startDateISO !== '' && todayISO !== '' && (
+          <StrengthProgressionCard
+            startDateISO={startDateISO}
+            todayISO={todayISO}
+          />
+        )}
+
+        {/* Streaks */}
+        <StreaksCard streaks={streaks} />
+
+        {/* Consistency grid (30 days) */}
         <ConsistencyGrid dots={consistencyDots} />
 
         {/* Rolling stats */}
@@ -491,6 +777,36 @@ const styles = StyleSheet.create({
     fontSize: Typography.sizes.xs,
     fontWeight: Typography.weights.semibold,
     color: Colors.textMuted,
+    flexShrink: 1,
+    marginLeft: Spacing.sm,
+    textAlign: 'right',
+  },
+
+  // ── 30/90-day toggle ─────────────────────────────────────────────────────────
+  toggleRow: {
+    flexDirection: 'row',
+    gap: Spacing.xs,
+    marginBottom: Spacing.md,
+    alignSelf: 'flex-start',
+  },
+  togglePill: {
+    borderRadius: Radius.full,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xs,
+    backgroundColor: Colors.canvasSunken,
+  },
+  togglePillActive: {
+    backgroundColor: Colors.sage,
+  },
+  togglePillText: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    fontWeight: Typography.weights.bold,
+    color: Colors.textMuted,
+    letterSpacing: 0.3,
+  },
+  togglePillTextActive: {
+    color: Colors.textOnAccent,
   },
 
   // ── Weight chart ─────────────────────────────────────────────────────────────
@@ -501,6 +817,10 @@ const styles = StyleSheet.create({
     color: Colors.sageDeep,
   },
   chartContainer: {
+    height: 80,
+    marginBottom: Spacing.lg,
+  },
+  strengthChartContainer: {
     height: 80,
     marginBottom: Spacing.lg,
   },
@@ -542,6 +862,14 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.sageDeep,
     marginBottom: Spacing.xs,
   },
+  strengthLastDot: {
+    width: 9,
+    height: 9,
+    borderRadius: Radius.full,
+    backgroundColor: Colors.sageDeep,
+    position: 'absolute',
+    top: Spacing.sm,
+  },
   barDateLabel: {
     position: 'absolute',
     bottom: -16,
@@ -574,7 +902,7 @@ const styles = StyleSheet.create({
     marginBottom: Spacing.md,
   },
   dot: {
-    width: 32,
+    width: 30,
     aspectRatio: 1,
     borderRadius: Radius.sm - 4,
   },
@@ -598,6 +926,42 @@ const styles = StyleSheet.create({
     fontSize: Typography.sizes.xs,
     fontWeight: Typography.weights.semibold,
     color: Colors.textSecondary,
+  },
+
+  // ── Streaks card ─────────────────────────────────────────────────────────────
+  streakRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  streakHeaderRow: {
+    marginBottom: Spacing.xs,
+  },
+  streakLabel: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    flex: 1,
+  },
+  streakHeaderText: {
+    fontFamily: Typography.label,
+    fontSize: 9,
+    fontWeight: Typography.weights.bold,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: Colors.textMuted,
+  },
+  streakValueLabel: {
+    fontFamily: Typography.label,
+    fontSize: 9,
+    fontWeight: Typography.weights.bold,
+    color: Colors.textMuted,
+    width: 56,
+    textAlign: 'center',
+  },
+  streakValueCell: {
+    width: 56,
+    alignItems: 'center',
   },
 
   // ── Rolling stats card ────────────────────────────────────────────────────────

--- a/src/screens/__tests__/analyticsHelpers.test.ts
+++ b/src/screens/__tests__/analyticsHelpers.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for analyticsHelpers.ts — pure functions, no DB required.
+ * Issue #265 — Analytics · strength progression + longer trends & streaks
+ */
+
+import {
+  computeStreaks,
+  computeStrengthProgression,
+  progressionSteps,
+  KG_PER_CYCLE,
+  CYCLE_DAYS,
+} from '../analyticsHelpers';
+
+// ─── computeStreaks ───────────────────────────────────────────────────────────
+
+describe('computeStreaks', () => {
+  const TODAY = '2024-03-15';
+
+  it('returns zeros for empty logs', () => {
+    const result = computeStreaks([], TODAY);
+    expect(result.gym).toEqual({ current: 0, longest: 0 });
+    expect(result.walk).toEqual({ current: 0, longest: 0 });
+    expect(result.fasting).toEqual({ current: 0, longest: 0 });
+  });
+
+  it('counts a current gym streak of 3 consecutive days ending today', () => {
+    const logs = [
+      { date: '2024-03-13', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-14', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-15', walk_completed: false, hammer_completed: true, fasting_completed: false },
+    ];
+    const { gym } = computeStreaks(logs, TODAY);
+    expect(gym.current).toBe(3);
+    expect(gym.longest).toBe(3);
+  });
+
+  it('breaks current streak if today is missed', () => {
+    const logs = [
+      { date: '2024-03-13', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-14', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-15', walk_completed: false, hammer_completed: false, fasting_completed: false },
+    ];
+    const { gym } = computeStreaks(logs, TODAY);
+    expect(gym.current).toBe(0);
+    expect(gym.longest).toBe(2);
+  });
+
+  it('breaks current streak if yesterday is missing from logs', () => {
+    const logs = [
+      { date: '2024-03-13', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      // 2024-03-14 absent
+      { date: '2024-03-15', walk_completed: false, hammer_completed: true, fasting_completed: false },
+    ];
+    const { gym } = computeStreaks(logs, TODAY);
+    // Only today counts because yesterday has no log entry
+    expect(gym.current).toBe(1);
+  });
+
+  it('computes longest walk streak across a gap', () => {
+    const logs = [
+      { date: '2024-03-01', walk_completed: true, hammer_completed: false, fasting_completed: false },
+      { date: '2024-03-02', walk_completed: true, hammer_completed: false, fasting_completed: false },
+      { date: '2024-03-03', walk_completed: true, hammer_completed: false, fasting_completed: false },
+      { date: '2024-03-04', walk_completed: false, hammer_completed: false, fasting_completed: false },
+      { date: '2024-03-05', walk_completed: true, hammer_completed: false, fasting_completed: false },
+      { date: '2024-03-06', walk_completed: true, hammer_completed: false, fasting_completed: false },
+    ];
+    const { walk } = computeStreaks(logs, TODAY);
+    expect(walk.longest).toBe(3);
+    expect(walk.current).toBe(0); // streak ended before today
+  });
+
+  it('computes fasting longest streak', () => {
+    const logs = [
+      { date: '2024-03-10', walk_completed: false, hammer_completed: false, fasting_completed: true },
+      { date: '2024-03-11', walk_completed: false, hammer_completed: false, fasting_completed: true },
+      { date: '2024-03-12', walk_completed: false, hammer_completed: false, fasting_completed: true },
+      { date: '2024-03-13', walk_completed: false, hammer_completed: false, fasting_completed: true },
+      { date: '2024-03-14', walk_completed: false, hammer_completed: false, fasting_completed: true },
+      { date: '2024-03-15', walk_completed: false, hammer_completed: false, fasting_completed: true },
+    ];
+    const { fasting } = computeStreaks(logs, TODAY);
+    expect(fasting.current).toBe(6);
+    expect(fasting.longest).toBe(6);
+  });
+
+  it('handles longest streak being longer than current', () => {
+    const logs = [
+      // old 5-day gym streak
+      { date: '2024-03-01', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-02', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-03', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-04', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-05', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      // gap
+      { date: '2024-03-10', walk_completed: false, hammer_completed: false, fasting_completed: false },
+      // recent 2-day gym streak
+      { date: '2024-03-14', walk_completed: false, hammer_completed: true, fasting_completed: false },
+      { date: '2024-03-15', walk_completed: false, hammer_completed: true, fasting_completed: false },
+    ];
+    const { gym } = computeStreaks(logs, TODAY);
+    expect(gym.current).toBe(2);
+    expect(gym.longest).toBe(5);
+  });
+});
+
+// ─── computeStrengthProgression ──────────────────────────────────────────────
+
+describe('computeStrengthProgression', () => {
+  it('returns empty array when start > end', () => {
+    const result = computeStrengthProgression('2024-03-10', '2024-03-01');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns a single point when start === end', () => {
+    const result = computeStrengthProgression('2024-03-01', '2024-03-01');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ date: '2024-03-01', weightKg: 0, cycle: 0 });
+  });
+
+  it('stays at cycle 0 for the first 21 days (CYCLE_DAYS)', () => {
+    const start = '2024-01-01';
+    // Day 0 to day 20 (21 days total) are all cycle 0
+    const end = '2024-01-21'; // day 20 (0-indexed)
+    const result = computeStrengthProgression(start, end);
+    expect(result).toHaveLength(21);
+    expect(result[0]).toEqual({ date: '2024-01-01', weightKg: 0, cycle: 0 });
+    expect(result[20]).toEqual({ date: '2024-01-21', weightKg: 0, cycle: 0 });
+  });
+
+  it('advances to cycle 1 on day 21', () => {
+    const start = '2024-01-01';
+    const end = '2024-01-22'; // day 21 = cycle 1
+    const result = computeStrengthProgression(start, end);
+    expect(result[21]).toEqual({
+      date: '2024-01-22',
+      weightKg: KG_PER_CYCLE,
+      cycle: 1,
+    });
+  });
+
+  it('computes correct weight at cycle 3', () => {
+    const start = '2024-01-01';
+    // Day 63 = 3 full cycles (63 / 21 = 3)
+    const day63 = new Date(2024, 0, 1);
+    day63.setDate(day63.getDate() + 63);
+    const endISO = formatDate(day63);
+    const result = computeStrengthProgression(start, endISO, 0);
+    const last = result[result.length - 1];
+    expect(last.cycle).toBe(3);
+    expect(last.weightKg).toBe(3 * KG_PER_CYCLE);
+  });
+
+  it('respects baselineKg offset', () => {
+    const result = computeStrengthProgression('2024-01-01', '2024-01-01', 100);
+    expect(result[0].weightKg).toBe(100);
+  });
+
+  it(`produces ${CYCLE_DAYS} days per cycle as expected`, () => {
+    expect(CYCLE_DAYS).toBe(21);
+    expect(KG_PER_CYCLE).toBe(5);
+  });
+});
+
+// ─── progressionSteps ────────────────────────────────────────────────────────
+
+describe('progressionSteps', () => {
+  it('returns empty array for empty input', () => {
+    expect(progressionSteps([])).toHaveLength(0);
+  });
+
+  it('returns just the single point for a single-item input', () => {
+    const pts = [{ date: '2024-01-01', weightKg: 0, cycle: 0 }];
+    expect(progressionSteps(pts)).toEqual(pts);
+  });
+
+  it('deduplicates consecutive same-weight points', () => {
+    // 21 days at 0kg, then moves to 5kg
+    const start = '2024-01-01';
+    const end = '2024-01-23'; // 22 days: days 0-21 at 0kg, day 22 at 5kg
+    const full = computeStrengthProgression(start, end);
+    const steps = progressionSteps(full);
+    // Expect: first point (0kg), step point (5kg on day 21), last point (same 5kg on day 22)
+    // Since last point == step point here (day 22), just 2 entries
+    expect(steps.length).toBeLessThan(full.length);
+    // First step = 0 kg
+    expect(steps[0].weightKg).toBe(0);
+    // Last step = 5 kg
+    expect(steps[steps.length - 1].weightKg).toBe(KG_PER_CYCLE);
+  });
+
+  it('always includes first and last points', () => {
+    const pts = [
+      { date: '2024-01-01', weightKg: 0, cycle: 0 },
+      { date: '2024-01-02', weightKg: 0, cycle: 0 },
+      { date: '2024-01-03', weightKg: 5, cycle: 1 },
+    ];
+    const steps = progressionSteps(pts);
+    expect(steps[0]).toEqual(pts[0]);
+    expect(steps[steps.length - 1]).toEqual(pts[pts.length - 1]);
+  });
+});
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}

--- a/src/screens/analyticsHelpers.ts
+++ b/src/screens/analyticsHelpers.ts
@@ -1,0 +1,246 @@
+/**
+ * analyticsHelpers.ts
+ *
+ * Pure, DB-free helper functions for AnalyticsDashboardScreen.
+ * All functions are side-effect free and fully unit-testable.
+ *
+ * Issue #265 — Analytics · strength progression + longer trends & streaks
+ */
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+export interface StreakResult {
+  current: number;
+  longest: number;
+}
+
+export interface StreakSet {
+  gym: StreakResult;
+  walk: StreakResult;
+  fasting: StreakResult;
+}
+
+export interface DailyLogSlice {
+  date: string;
+  walk_completed: boolean;
+  hammer_completed: boolean;
+  fasting_completed: boolean;
+}
+
+export interface StrengthPoint {
+  date: string;
+  /** Weight in kg at baseline + progression */
+  weightKg: number;
+  /** 0-based cycle index */
+  cycle: number;
+}
+
+// ─────────────────────────────────────────────
+// Streak computation
+// ─────────────────────────────────────────────
+
+/**
+ * Compute current and longest streaks for gym, walk, and fasting
+ * from an array of daily-log slices (any date range, any order).
+ *
+ * "Current" streak = consecutive days ending on `todayISO` (going back).
+ * "Longest" streak = maximum consecutive run across the full window.
+ *
+ * A day that is absent from the logs array is treated as missed.
+ *
+ * @param logs - Array of daily log slices, any order.
+ * @param todayISO - ISO date string for today (YYYY-MM-DD).
+ */
+export function computeStreaks(
+  logs: DailyLogSlice[],
+  todayISO: string
+): StreakSet {
+  // Build a map of date -> flags for O(1) lookups
+  const byDate = new Map<string, DailyLogSlice>();
+  for (const l of logs) {
+    byDate.set(l.date, l);
+  }
+
+  // Sort all known dates ascending
+  const sortedDates = [...byDate.keys()].sort();
+
+  if (sortedDates.length === 0) {
+    const zero: StreakResult = { current: 0, longest: 0 };
+    return { gym: zero, walk: zero, fasting: zero };
+  }
+
+  // ── Longest streaks (scan forward) ──────────────────────────────────────────
+  // Walk consecutive days: if a date is missing from sortedDates we can't
+  // assume it is "missed" for the longest calc because getRollingWindow may
+  // only return a window (e.g. ±7 days).  We therefore only count gaps as
+  // breaks when two adjacent rows in sortedDates are more than 1 calendar day
+  // apart (explicit gap) OR when the flag is false.
+
+  function computeLongest(flag: (l: DailyLogSlice) => boolean): number {
+    let longest = 0;
+    let run = 0;
+    let prevDate: string | null = null;
+
+    for (const d of sortedDates) {
+      const l = byDate.get(d)!;
+      const isConsecutive =
+        prevDate !== null && dateDiffDays(prevDate, d) === 1;
+
+      if (!isConsecutive && prevDate !== null) {
+        // Gap in dates — reset run
+        run = 0;
+      }
+
+      if (flag(l)) {
+        run++;
+        if (run > longest) longest = run;
+      } else {
+        run = 0;
+      }
+      prevDate = d;
+    }
+    return longest;
+  }
+
+  const longestGym = computeLongest((l) => l.hammer_completed);
+  const longestWalk = computeLongest((l) => l.walk_completed);
+  const longestFasting = computeLongest((l) => l.fasting_completed);
+
+  // ── Current streaks (scan backward from today) ───────────────────────────────
+  function computeCurrent(flag: (l: DailyLogSlice) => boolean): number {
+    let streak = 0;
+    let cursor = todayISO;
+
+    // Walk backwards day by day
+    for (let i = 0; i < 366; i++) {
+      const entry = byDate.get(cursor);
+      if (!entry) break; // day not in logs → streak ends
+      if (!flag(entry)) break;
+      streak++;
+      cursor = offsetDate(cursor, -1);
+    }
+    return streak;
+  }
+
+  const currentGym = computeCurrent((l) => l.hammer_completed);
+  const currentWalk = computeCurrent((l) => l.walk_completed);
+  const currentFasting = computeCurrent((l) => l.fasting_completed);
+
+  return {
+    gym: { current: currentGym, longest: longestGym },
+    walk: { current: currentWalk, longest: longestWalk },
+    fasting: { current: currentFasting, longest: longestFasting },
+  };
+}
+
+// ─────────────────────────────────────────────
+// Strength progression computation
+// ─────────────────────────────────────────────
+
+/** Baseline label when no cycles have elapsed yet */
+export const BASELINE_LABEL = 'Baseline';
+
+/** Number of kg added per completed cycle */
+export const KG_PER_CYCLE = 5;
+
+/** Number of days per cycle */
+export const CYCLE_DAYS = 21;
+
+/**
+ * Compute the gym-weight progression curve from `startDateISO` up to
+ * `endDateISO` (inclusive), sampled daily.
+ *
+ * The weight at any date is:  baseline + floor((daysDiff / CYCLE_DAYS)) * KG_PER_CYCLE
+ * where daysDiff = calendar days since startDateISO (0 on start day).
+ *
+ * Returns an empty array if startDateISO > endDateISO.
+ *
+ * @param startDateISO - App start date (from getStartDate()).
+ * @param endDateISO   - Last date to include (usually today).
+ * @param baselineKg   - Baseline weight (shown as "Baseline" in the chart).
+ *                       We use 0 here and let the UI show relative kg added.
+ */
+export function computeStrengthProgression(
+  startDateISO: string,
+  endDateISO: string,
+  baselineKg: number = 0
+): StrengthPoint[] {
+  const start = parseISO(startDateISO);
+  const end = parseISO(endDateISO);
+
+  if (start > end) return [];
+
+  const result: StrengthPoint[] = [];
+  let cursor = new Date(start);
+
+  while (cursor <= end) {
+    const iso = formatISO(cursor);
+    const daysDiff = Math.round(
+      (cursor.getTime() - start.getTime()) / 86_400_000
+    );
+    const cycle = Math.floor(daysDiff / CYCLE_DAYS);
+    const weightKg = baselineKg + cycle * KG_PER_CYCLE;
+    result.push({ date: iso, weightKg, cycle });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return result;
+}
+
+/**
+ * Given the full progression series, return a deduplicated list of
+ * "step" points — one entry per cycle boundary (where weight changes).
+ * The first point and the last point are always included.
+ *
+ * Useful for rendering a step-line chart without plotting every single day.
+ */
+export function progressionSteps(points: StrengthPoint[]): StrengthPoint[] {
+  if (points.length === 0) return [];
+  const steps: StrengthPoint[] = [points[0]];
+  for (let i = 1; i < points.length; i++) {
+    if (points[i].weightKg !== points[i - 1].weightKg) {
+      steps.push(points[i]);
+    }
+  }
+  // Always include the last point (current)
+  if (steps[steps.length - 1] !== points[points.length - 1]) {
+    steps.push(points[points.length - 1]);
+  }
+  return steps;
+}
+
+// ─────────────────────────────────────────────
+// Date utilities (no external dep)
+// ─────────────────────────────────────────────
+
+/** Parse an ISO date string (YYYY-MM-DD) as midnight UTC-independent Date. */
+function parseISO(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+/** Format a Date as YYYY-MM-DD. */
+function formatISO(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/** Return how many calendar days b is after a (negative if before). */
+function dateDiffDays(a: string, b: string): number {
+  const da = parseISO(a);
+  const db = parseISO(b);
+  return Math.round((db.getTime() - da.getTime()) / 86_400_000);
+}
+
+/** Return an ISO date string offset by `days` from `isoDate`. */
+function offsetDate(isoDate: string, days: number): string {
+  const d = parseISO(isoDate);
+  d.setDate(d.getDate() + days);
+  return formatISO(d);
+}


### PR DESCRIPTION
## Summary

Two new feature areas extending `AnalyticsDashboardScreen` — no new npm dependencies, no schema migration, View-based charts only.

### 1. Strength progression chart

A new `StrengthProgressionCard` shows how the gym weight has progressed over time via the existing 21-day auto-progression cycle.

**How weights are derived:** `getStartDate()` returns the ISO start date stored in `app_state`. For any given date, `daysDiff = calendar days since start`. The cycle index is `floor(daysDiff / CYCLE_DAYS)` (CYCLE_DAYS=21). The weight added is `cycle * KG_PER_CYCLE` (KG_PER_CYCLE=5kg). This exactly mirrors the `buildHammerTask` logic in `database.ts`. The pure function `computeStrengthProgression(startISO, endISO, baselineKg)` in `analyticsHelpers.ts` produces a daily series; `progressionSteps()` deduplicates it to step-boundary points for chart rendering.

- Covers last 90 days (or since start date, whichever is shorter)
- Step-line rendered as View-based bars (sage fill, sageDeep on current bar) — same visual language as the weight chart
- Subtitle shows current cycle number and total kg added (e.g. "Cycle 3 · +15kg added")
- Early-state graceful message: "Progression builds over your first cycle (21 days)"

### 2. Longer trends & streaks

**Weight trend 30/90-day toggle:** a Pill-style segmented control (built from TouchableOpacity + Verdure tokens — no new component) switches the existing weight bar chart between 30 and 90 days. Both windows are fetched in `loadData` via `getWeightHistory(30)` and `getWeightHistory(90)`.

**Streaks card:** `StreaksCard` shows current and longest streaks for gym, walking, and fasting in a clean two-column layout (Current | Best). Streaks computed by the pure `computeStreaks()` helper using `getRollingWindow()` logs. Pill accent colours: sage for gym/walk, sky for fasting.

**30-day consistency grid:** extended from 14 days to 30 days. Dot width reduced from 32px to 30px so 7 columns stay comfortable. Same complete/partial/missed coloring and legend.

### Implementation notes

- New file `src/screens/analyticsHelpers.ts` — pure side-effect-free helpers (`computeStreaks`, `computeStrengthProgression`, `progressionSteps`, re-exported constants).
- New file `src/screens/__tests__/analyticsHelpers.test.ts` — 18 focused unit tests covering all helpers, edge cases (empty input, early state, longest > current, cycle boundaries).
- All styling via `src/theme/tokens.ts` (Colors/Spacing/Typography/Radius). No raw hex, no magic numbers.
- View-based charts, no charting library. No new npm dependencies. No schema migration needed.

### Quality gate

- `npm run typecheck` — pass
- `npm test` — 123/123 tests pass (10 suites)

Closes #265