### PR TITLE
Analytics · nutrition adherence + meal & recipe insights

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -948,22 +948,31 @@ export async function getMealInventory(): Promise<MealInventoryWithRecipe[]> {
 export async function logCookedMeal(recipe_id: string, portions: number): Promise<void> {
   const db = getDatabase();
   const date_cooked = toISODate();
-  // Check if active stock exists
-  const existing = await db.getFirstAsync<any>(
-    'SELECT * FROM meal_inventory WHERE recipe_id = ? AND portions_available > 0', 
-    [recipe_id]
-  );
-  if (existing) {
-    await db.runAsync(
-      'UPDATE meal_inventory SET portions_available = portions_available + ?, date_cooked = ? WHERE id = ?',
-      [portions, date_cooked, existing.id]
+
+  await db.withTransactionAsync(async () => {
+    // Check if active stock exists
+    const existing = await db.getFirstAsync<any>(
+      'SELECT * FROM meal_inventory WHERE recipe_id = ? AND portions_available > 0',
+      [recipe_id]
     );
-  } else {
+    if (existing) {
+      await db.runAsync(
+        'UPDATE meal_inventory SET portions_available = portions_available + ?, date_cooked = ? WHERE id = ?',
+        [portions, date_cooked, existing.id]
+      );
+    } else {
+      await db.runAsync(
+        'INSERT INTO meal_inventory (recipe_id, portions_available, date_cooked) VALUES (?, ?, ?)',
+        [recipe_id, portions, date_cooked]
+      );
+    }
+
+    // Persist cook event to cook_log so history accumulates for analytics (#267 v30)
     await db.runAsync(
-      'INSERT INTO meal_inventory (recipe_id, portions_available, date_cooked) VALUES (?, ?, ?)',
+      'INSERT INTO cook_log (recipe_id, portions, date) VALUES (?, ?, ?)',
       [recipe_id, portions, date_cooked]
     );
-  }
+  });
 }
 
 export async function getWeeklyMealPlan(): Promise<WeeklyMealPlanItem[]> {
@@ -1193,4 +1202,266 @@ export async function finishCooking(
 export async function deleteCookingTask(taskId: number): Promise<void> {
   const db = getDatabase();
   await db.runAsync('DELETE FROM cooking_tasks WHERE id = ?', [taskId]);
+}
+
+// ─────────────────────────────────────────────
+// Nutrition Analytics Queries (#267)
+// ─────────────────────────────────────────────
+
+export interface DailyMacroTotals {
+  date: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  /** Number of consumed meals that contributed to this day's totals. */
+  mealCount: number;
+}
+
+/**
+ * Return per-day macro totals (calories, protein, carbs, fat) from meals
+ * that were marked as consumed in weekly_meal_plan, joined to recipe_library
+ * for macro values. Only days that have at least one consumed meal appear.
+ *
+ * @param days - How many calendar days back to look (default 30).
+ */
+export async function getConsumedMacrosByDay(days: number = 30): Promise<DailyMacroTotals[]> {
+  const db = getDatabase();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const cutoffISO = toISODate(cutoff);
+
+  const rows = await db.getAllAsync<{
+    date: string;
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+    meal_count: number;
+  }>(
+    `SELECT
+       p.date,
+       SUM(r.calories) AS calories,
+       SUM(r.protein)  AS protein,
+       SUM(r.carbs)    AS carbs,
+       SUM(r.fat)      AS fat,
+       COUNT(*)        AS meal_count
+     FROM weekly_meal_plan p
+     JOIN recipe_library r ON p.recipe_id = r.id
+     WHERE p.is_consumed = 1
+       AND p.date >= ?
+     GROUP BY p.date
+     ORDER BY p.date ASC`,
+    [cutoffISO]
+  );
+
+  return rows.map((r) => ({
+    date: r.date,
+    calories: r.calories ?? 0,
+    protein: r.protein ?? 0,
+    carbs: r.carbs ?? 0,
+    fat: r.fat ?? 0,
+    mealCount: r.meal_count ?? 0,
+  }));
+}
+
+export interface MealAdherenceSummary {
+  /** Total meals that were planned (all weekly_meal_plan rows in window). */
+  planned: number;
+  /** Total meals that were consumed (is_consumed = 1) in the same window. */
+  consumed: number;
+  /** consumed / planned as a 0–1 fraction; 0 when planned = 0. */
+  adherenceRatio: number;
+}
+
+/**
+ * Compute meal plan adherence: how many planned meals were actually consumed
+ * over the past `days` calendar days.
+ *
+ * @param days - Window size in days (default 30).
+ */
+export async function getMealAdherence(days: number = 30): Promise<MealAdherenceSummary> {
+  const db = getDatabase();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const cutoffISO = toISODate(cutoff);
+
+  const row = await db.getFirstAsync<{ planned: number; consumed: number }>(
+    `SELECT
+       COUNT(*) AS planned,
+       SUM(CASE WHEN is_consumed = 1 THEN 1 ELSE 0 END) AS consumed
+     FROM weekly_meal_plan
+     WHERE date >= ?`,
+    [cutoffISO]
+  );
+
+  const planned = row?.planned ?? 0;
+  const consumed = row?.consumed ?? 0;
+  return {
+    planned,
+    consumed,
+    adherenceRatio: planned > 0 ? consumed / planned : 0,
+  };
+}
+
+export interface EatenRecipeRow {
+  recipe_id: string;
+  title: string;
+  count: number;
+}
+
+/**
+ * Return the top `limit` most-consumed recipes from weekly_meal_plan history,
+ * ordered by consumed count descending.
+ *
+ * @param limit - Maximum number of recipes to return (default 5).
+ */
+export async function getMostEatenRecipes(limit: number = 5): Promise<EatenRecipeRow[]> {
+  const db = getDatabase();
+  const rows = await db.getAllAsync<{ recipe_id: string; title: string; count: number }>(
+    `SELECT p.recipe_id, r.title, COUNT(*) AS count
+     FROM weekly_meal_plan p
+     JOIN recipe_library r ON p.recipe_id = r.id
+     WHERE p.is_consumed = 1
+     GROUP BY p.recipe_id
+     ORDER BY count DESC
+     LIMIT ?`,
+    [limit]
+  );
+
+  return rows.map((r) => ({
+    recipe_id: r.recipe_id,
+    title: r.title,
+    count: r.count,
+  }));
+}
+
+export interface AverageConsumedMacros {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  /** Total number of consumed meal rows used in the average. */
+  sampleSize: number;
+}
+
+/**
+ * Compute average per-meal macros (calories, protein, carbs, fat) across all
+ * meals that have been marked consumed in weekly_meal_plan.
+ *
+ * Returns zeros with sampleSize = 0 when no consumed meals exist.
+ */
+export async function getAverageConsumedMacros(): Promise<AverageConsumedMacros> {
+  const db = getDatabase();
+  const row = await db.getFirstAsync<{
+    calories: number | null;
+    protein: number | null;
+    carbs: number | null;
+    fat: number | null;
+    sample_size: number;
+  }>(
+    `SELECT
+       AVG(r.calories) AS calories,
+       AVG(r.protein)  AS protein,
+       AVG(r.carbs)    AS carbs,
+       AVG(r.fat)      AS fat,
+       COUNT(*)        AS sample_size
+     FROM weekly_meal_plan p
+     JOIN recipe_library r ON p.recipe_id = r.id
+     WHERE p.is_consumed = 1`
+  );
+
+  return {
+    calories: Math.round(row?.calories ?? 0),
+    protein: Math.round(row?.protein ?? 0),
+    carbs: Math.round(row?.carbs ?? 0),
+    fat: Math.round(row?.fat ?? 0),
+    sampleSize: row?.sample_size ?? 0,
+  };
+}
+
+export interface CookedRecipeRow {
+  recipe_id: string;
+  title: string;
+  totalPortions: number;
+  cookEvents: number;
+}
+
+/**
+ * Return the top `limit` most-cooked recipes from cook_log (v30), ordered by
+ * total portions cooked descending. Returns an empty array when cook_log has
+ * no rows yet (the table is new — data accumulates as the user cooks).
+ *
+ * @param limit - Maximum number of recipes to return (default 5).
+ */
+export async function getMostCookedRecipes(limit: number = 5): Promise<CookedRecipeRow[]> {
+  const db = getDatabase();
+  const rows = await db.getAllAsync<{
+    recipe_id: string;
+    title: string;
+    total_portions: number;
+    cook_events: number;
+  }>(
+    `SELECT cl.recipe_id, r.title,
+            SUM(cl.portions) AS total_portions,
+            COUNT(*)          AS cook_events
+     FROM cook_log cl
+     JOIN recipe_library r ON cl.recipe_id = r.id
+     GROUP BY cl.recipe_id
+     ORDER BY total_portions DESC
+     LIMIT ?`,
+    [limit]
+  );
+
+  return rows.map((r) => ({
+    recipe_id: r.recipe_id,
+    title: r.title,
+    totalPortions: r.total_portions ?? 0,
+    cookEvents: r.cook_events ?? 0,
+  }));
+}
+
+export interface InventorySnapshot {
+  /** Total number of distinct recipes currently in stock. */
+  recipesInStock: number;
+  /** Sum of portions_available across all in-stock recipes. */
+  totalPortions: number;
+  /** Per-recipe rows for display. */
+  items: Array<{
+    recipe_id: string;
+    title: string;
+    portionsAvailable: number;
+  }>;
+}
+
+/**
+ * Return a snapshot of the current meal inventory: how many recipes are in
+ * stock and their available portion counts. Uses meal_inventory joined to
+ * recipe_library. Empty when no meals are currently prepared.
+ */
+export async function getInventorySnapshot(): Promise<InventorySnapshot> {
+  const db = getDatabase();
+  const rows = await db.getAllAsync<{
+    recipe_id: string;
+    title: string;
+    portions_available: number;
+  }>(
+    `SELECT m.recipe_id, r.title, m.portions_available
+     FROM meal_inventory m
+     JOIN recipe_library r ON m.recipe_id = r.id
+     WHERE m.portions_available > 0
+     ORDER BY m.portions_available DESC`
+  );
+
+  const totalPortions = rows.reduce((sum, r) => sum + (r.portions_available ?? 0), 0);
+
+  return {
+    recipesInStock: rows.length,
+    totalPortions,
+    items: rows.map((r) => ({
+      recipe_id: r.recipe_id,
+      title: r.title,
+      portionsAvailable: r.portions_available,
+    })),
+  };
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -560,4 +560,16 @@ export const MIGRATIONS: Migration[] = [
     fetched_at TEXT NOT NULL
   );
 ` },
+  // v30: Cook log — persistent record of every cook event (recipe_id, portions, date).
+  // Populated by logCookedMeal() going forward. Enables cook-history analytics
+  // (most-cooked recipes, inventory turnover) that cannot be derived from meal_inventory
+  // alone (which only tracks current stock).
+  { version: 30, sql: `
+  CREATE TABLE IF NOT EXISTS cook_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recipe_id TEXT NOT NULL,
+    portions INTEGER NOT NULL,
+    date TEXT NOT NULL
+  );
+` },
 ];

--- a/src/nutrition/goals.ts
+++ b/src/nutrition/goals.ts
@@ -1,0 +1,38 @@
+/**
+ * goals.ts — Default daily nutrition targets for the HealthTracker app.
+ *
+ * These are sensible starting defaults for a moderate-activity adult on a
+ * muscle-building / body-recomposition program. They are intentionally
+ * exported as named constants so a future Settings screen can load user
+ * overrides from the database and fall back to these values.
+ *
+ * Usage:
+ *   import { NUTRITION_GOALS } from '../nutrition/goals';
+ *   // goals.calories, goals.protein
+ *
+ * Future: replace the literals below with a DB-backed `getUserGoals()` that
+ * returns stored overrides merged over NUTRITION_GOALS as the default.
+ */
+
+export interface NutritionGoals {
+  /** Target daily caloric intake in kcal. */
+  calories: number;
+  /** Target daily protein intake in grams. */
+  protein: number;
+}
+
+/**
+ * Default daily nutrition goals.
+ *
+ * calories: 1800 kcal — moderate deficit / maintenance for a typical
+ *   85–95 kg male in a meal-prep program.
+ * protein:  150 g   — ~1.6–1.8 g / kg body weight for muscle retention.
+ *
+ * These defaults are NOT personalised. A future Settings screen will allow
+ * the user to override them; store overrides in app_state under
+ * 'nutrition_goal_calories' / 'nutrition_goal_protein' and merge here.
+ */
+export const NUTRITION_GOALS: NutritionGoals = {
+  calories: 1800,
+  protein: 150,
+};

--- a/src/screens/AnalyticsDashboardScreen.tsx
+++ b/src/screens/AnalyticsDashboardScreen.tsx
@@ -3,6 +3,7 @@
  *
  * Verdure redesign: Unit 10 (#245)
  * Extended with strength progression + longer trends & streaks: #265
+ * Extended with nutrition adherence + meal & recipe insights: #267
  *
  * Behaviour-preserving restyle only. All DB queries and metric calculations
  * are unchanged. Presentation updated to the Verdure calm-wellness system
@@ -17,6 +18,12 @@
  *   - Streaks card: current + longest for gym, walk, fasting
  *   - Consistency grid: 7-col rounded dot grid (sage/gold/canvasSunken) 30-day + legend
  *   - 7-day / 30-day rolling stats with ProgressBar rows
+ *   - Nutrition section:
+ *       · Daily calorie + protein trend (View-based chart, goal reference line)
+ *       · Plan adherence ProgressBar
+ *       · Most-eaten recipes ranked list
+ *       · Average macros stat card
+ *       · Most-cooked recipes (cook_log, builds over time) + inventory snapshot
  */
 import React, { useState, useCallback } from 'react';
 import {
@@ -34,6 +41,18 @@ import {
   getWeightHistory,
   getStartDate,
   toISODate,
+  getConsumedMacrosByDay,
+  getMealAdherence,
+  getMostEatenRecipes,
+  getAverageConsumedMacros,
+  getMostCookedRecipes,
+  getInventorySnapshot,
+  type DailyMacroTotals,
+  type MealAdherenceSummary,
+  type EatenRecipeRow,
+  type AverageConsumedMacros,
+  type CookedRecipeRow,
+  type InventorySnapshot,
 } from '../db/database';
 import { Card, ProgressBar, ScreenHeader, Pill } from '../components';
 import {
@@ -42,7 +61,10 @@ import {
   progressionSteps,
   StreakSet,
   KG_PER_CYCLE,
+  normaliseMacroSeries,
+  macroChartDateLabel,
 } from './analyticsHelpers';
+import { NUTRITION_GOALS } from '../nutrition/goals';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -499,6 +521,298 @@ function RollingStatsCard({
   );
 }
 
+// ─── Nutrition: Daily macro trend chart ───────────────────────────────────────
+
+function MacroTrendChart({
+  macros,
+  macroKey,
+  goal,
+  label,
+  accentColor,
+}: {
+  macros: DailyMacroTotals[];
+  macroKey: 'calories' | 'protein';
+  goal: number;
+  label: string;
+  accentColor: string;
+}) {
+  if (macros.length === 0) return null;
+
+  const normalised = normaliseMacroSeries(
+    macros.map((m) => ({ date: m.date, calories: m.calories, protein: m.protein })),
+    macroKey,
+    goal
+  );
+  const total = macros.length;
+  const latest = macros[total - 1][macroKey];
+
+  return (
+    <View style={styles.macroChartBlock}>
+      <View style={styles.macroChartHeader}>
+        <Text style={styles.macroChartLabel}>{label}</Text>
+        <Text style={styles.macroChartValue}>
+          {latest} {macroKey === 'calories' ? 'kcal' : 'g'} today
+        </Text>
+      </View>
+
+      {/* Bar chart area */}
+      <View style={styles.macroChartContainer}>
+        {/* Soft tint background */}
+        <View style={[styles.macroChartBg, { backgroundColor: accentColor + '18' }]} />
+
+        {/* Goal reference line — positioned at 100% height (top) */}
+        <View style={styles.macroGoalLine} />
+
+        {/* Bars */}
+        <View style={styles.macroBarsLayer}>
+          {normalised.map((ratio, i) => {
+            const heightPct = Math.max(4, ratio * 100);
+            const isLast = i === total - 1;
+            const dateLabel = macroChartDateLabel(i, total, macros[i].date);
+            return (
+              <View key={`mbar-${macroKey}-${i}`} style={styles.macroBarCol}>
+                <View
+                  style={[
+                    styles.macroBar,
+                    {
+                      height: `${heightPct}%`,
+                      backgroundColor: isLast ? accentColor : accentColor + 'AA',
+                    },
+                  ]}
+                />
+                {dateLabel !== '' && (
+                  <Text style={styles.macroBarDateLabel}>{dateLabel}</Text>
+                )}
+              </View>
+            );
+          })}
+        </View>
+      </View>
+
+      {/* Goal annotation */}
+      <Text style={styles.macroGoalAnnotation}>
+        Goal: {goal} {macroKey === 'calories' ? 'kcal' : 'g'}
+      </Text>
+    </View>
+  );
+}
+
+// ─── Nutrition: Section card ──────────────────────────────────────────────────
+
+function NutritionSectionCard({
+  macros,
+  adherence,
+  mostEaten,
+  avgMacros,
+  mostCooked,
+  inventory,
+}: {
+  macros: DailyMacroTotals[];
+  adherence: MealAdherenceSummary;
+  mostEaten: EatenRecipeRow[];
+  avgMacros: AverageConsumedMacros;
+  mostCooked: CookedRecipeRow[];
+  inventory: InventorySnapshot;
+}) {
+  const hasConsumedHistory = macros.length > 0;
+  const hasMostEaten = mostEaten.length > 0;
+  const hasCookLog = mostCooked.length > 0;
+
+  return (
+    <>
+      {/* Section divider header */}
+      <View style={styles.sectionDivider}>
+        <Text style={styles.sectionDividerText}>Nutrition</Text>
+      </View>
+
+      {/* 1. Nutrition adherence card */}
+      <Card style={styles.sectionCard}>
+        <View style={styles.cardTitleRow}>
+          <Text style={styles.cardSectionTitle}>Nutrition adherence</Text>
+          <Text style={styles.cardSectionTrailing}>Last 30 days</Text>
+        </View>
+
+        {!hasConsumedHistory ? (
+          <Text style={styles.emptyText}>
+            Log meals as consumed to see adherence.
+          </Text>
+        ) : (
+          <>
+            {/* Calorie trend chart */}
+            <MacroTrendChart
+              macros={macros}
+              macroKey="calories"
+              goal={NUTRITION_GOALS.calories}
+              label="Calories"
+              accentColor={Colors.clay}
+            />
+
+            {/* Protein trend chart */}
+            <MacroTrendChart
+              macros={macros}
+              macroKey="protein"
+              goal={NUTRITION_GOALS.protein}
+              label="Protein"
+              accentColor={Colors.sage}
+            />
+          </>
+        )}
+
+        {/* Plan adherence bar — available whenever there are any planned meals */}
+        {adherence.planned > 0 ? (
+          <View style={styles.adherenceRow}>
+            <Text style={styles.adherenceLabel}>Plan adherence</Text>
+            <ProgressBar
+              progress={adherence.adherenceRatio}
+              height={7}
+              style={styles.adherenceBar}
+            />
+            <Pill
+              label={`${Math.round(adherence.adherenceRatio * 100)}%`}
+              accent="clay"
+            />
+          </View>
+        ) : (
+          <Text style={[styles.emptyText, hasConsumedHistory ? { marginTop: Spacing.md } : {}]}>
+            Plan meals to track adherence.
+          </Text>
+        )}
+      </Card>
+
+      {/* 2. Recipe insights card */}
+      <Card style={styles.sectionCard}>
+        <Text style={styles.cardSectionTitle}>Meal insights</Text>
+
+        {/* Most-eaten recipes */}
+        <Text style={styles.insightSubheading}>Most eaten</Text>
+        {!hasMostEaten ? (
+          <Text style={styles.emptyText}>
+            Mark meals as consumed to see your top recipes.
+          </Text>
+        ) : (
+          <View style={styles.recipeRankList}>
+            {mostEaten.map((r, i) => (
+              <View key={r.recipe_id} style={styles.recipeRankRow}>
+                <View style={styles.recipeRankBadge}>
+                  <Text style={styles.recipeRankNum}>{i + 1}</Text>
+                </View>
+                <Text style={styles.recipeRankTitle} numberOfLines={1}>
+                  {r.title}
+                </Text>
+                <Pill label={`${r.count}x`} accent="clay" />
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Average macros */}
+        {avgMacros.sampleSize > 0 && (
+          <>
+            <Text style={[styles.insightSubheading, { marginTop: Spacing.md }]}>
+              Average per meal
+            </Text>
+            <View style={styles.avgMacrosRow}>
+              <View style={styles.avgMacroCell}>
+                <Text style={styles.avgMacroValue}>{avgMacros.calories}</Text>
+                <Text style={styles.avgMacroUnit}>kcal</Text>
+              </View>
+              <View style={styles.avgMacroCell}>
+                <Text style={[styles.avgMacroValue, { color: Colors.sage }]}>
+                  {avgMacros.protein}g
+                </Text>
+                <Text style={styles.avgMacroUnit}>protein</Text>
+              </View>
+              <View style={styles.avgMacroCell}>
+                <Text style={[styles.avgMacroValue, { color: Colors.gold }]}>
+                  {avgMacros.carbs}g
+                </Text>
+                <Text style={styles.avgMacroUnit}>carbs</Text>
+              </View>
+              <View style={styles.avgMacroCell}>
+                <Text style={[styles.avgMacroValue, { color: Colors.sky }]}>
+                  {avgMacros.fat}g
+                </Text>
+                <Text style={styles.avgMacroUnit}>fat</Text>
+              </View>
+            </View>
+            <Text style={styles.avgMacroSample}>
+              Based on {avgMacros.sampleSize} consumed{' '}
+              {avgMacros.sampleSize === 1 ? 'meal' : 'meals'}
+            </Text>
+          </>
+        )}
+      </Card>
+
+      {/* 3. Cook history & inventory card */}
+      <Card style={styles.sectionCard}>
+        <Text style={styles.cardSectionTitle}>Cook history & stock</Text>
+
+        {/* Most cooked — only once cook_log has data */}
+        <Text style={styles.insightSubheading}>Most cooked</Text>
+        {!hasCookLog ? (
+          <Text style={styles.emptyText}>
+            Builds as you cook — finish cooking tasks to start tracking.
+          </Text>
+        ) : (
+          <View style={styles.recipeRankList}>
+            {mostCooked.map((r, i) => (
+              <View key={r.recipe_id} style={styles.recipeRankRow}>
+                <View style={[styles.recipeRankBadge, styles.recipeRankBadgeSage]}>
+                  <Text style={[styles.recipeRankNum, styles.recipeRankNumSage]}>
+                    {i + 1}
+                  </Text>
+                </View>
+                <Text style={styles.recipeRankTitle} numberOfLines={1}>
+                  {r.title}
+                </Text>
+                <Pill label={`${r.totalPortions}p`} accent="sage" />
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Current inventory snapshot — always shown */}
+        <Text style={[styles.insightSubheading, { marginTop: Spacing.md }]}>
+          Current stock
+        </Text>
+        {inventory.recipesInStock === 0 ? (
+          <Text style={styles.emptyText}>No meals in stock right now.</Text>
+        ) : (
+          <>
+            <View style={styles.inventorySummaryRow}>
+              <View style={styles.inventoryStatCell}>
+                <Text style={styles.inventoryStatValue}>
+                  {inventory.recipesInStock}
+                </Text>
+                <Text style={styles.inventoryStatLabel}>recipes</Text>
+              </View>
+              <View style={styles.inventoryStatCell}>
+                <Text style={[styles.inventoryStatValue, { color: Colors.sageDeep }]}>
+                  {inventory.totalPortions}
+                </Text>
+                <Text style={styles.inventoryStatLabel}>portions</Text>
+              </View>
+            </View>
+            {inventory.items.slice(0, 4).map((item) => (
+              <View key={item.recipe_id} style={styles.inventoryItemRow}>
+                <Text style={styles.inventoryItemTitle} numberOfLines={1}>
+                  {item.title}
+                </Text>
+                <Pill label={`${item.portionsAvailable}p`} accent="sage" />
+              </View>
+            ))}
+            {inventory.items.length > 4 && (
+              <Text style={styles.inventoryMoreLabel}>
+                +{inventory.items.length - 4} more
+              </Text>
+            )}
+          </>
+        )}
+      </Card>
+    </>
+  );
+}
+
 // ─── Screen ───────────────────────────────────────────────────────────────────
 
 export default function AnalyticsDashboardScreen() {
@@ -524,6 +838,28 @@ export default function AnalyticsDashboardScreen() {
   const [weightDelta, setWeightDelta] = useState<number | null>(null);
   const [workoutCount30, setWorkoutCount30] = useState(0);
   const [fastingStreak, setFastingStreak] = useState(0);
+
+  // ── Nutrition analytics state ────────────────────────────────────────────────
+  const [consumedMacros, setConsumedMacros] = useState<DailyMacroTotals[]>([]);
+  const [mealAdherence, setMealAdherence] = useState<MealAdherenceSummary>({
+    planned: 0,
+    consumed: 0,
+    adherenceRatio: 0,
+  });
+  const [mostEatenRecipes, setMostEatenRecipes] = useState<EatenRecipeRow[]>([]);
+  const [avgMacros, setAvgMacros] = useState<AverageConsumedMacros>({
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+    sampleSize: 0,
+  });
+  const [mostCookedRecipes, setMostCookedRecipes] = useState<CookedRecipeRow[]>([]);
+  const [inventorySnapshot, setInventorySnapshot] = useState<InventorySnapshot>({
+    recipesInStock: 0,
+    totalPortions: 0,
+    items: [],
+  });
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -623,6 +959,24 @@ export default function AnalyticsDashboardScreen() {
         }
       }
       setConsistencyDots(dots);
+
+      // ── Nutrition analytics (#267) ──────────────────────────────────────────
+      const [macrosByDay, adherence, topEaten, avgM, topCooked, invSnapshot] =
+        await Promise.all([
+          getConsumedMacrosByDay(30),
+          getMealAdherence(30),
+          getMostEatenRecipes(5),
+          getAverageConsumedMacros(),
+          getMostCookedRecipes(5),
+          getInventorySnapshot(),
+        ]);
+
+      setConsumedMacros(macrosByDay);
+      setMealAdherence(adherence);
+      setMostEatenRecipes(topEaten);
+      setAvgMacros(avgM);
+      setMostCookedRecipes(topCooked);
+      setInventorySnapshot(invSnapshot);
     } catch (err) {
       console.error('Failed to load analytics', err);
     } finally {
@@ -700,6 +1054,16 @@ export default function AnalyticsDashboardScreen() {
         {/* Rolling stats */}
         <RollingStatsCard title="7-Day Rolling Stats" stats={stats7Day} />
         <RollingStatsCard title="30-Day Rolling Stats" stats={stats30Day} />
+
+        {/* Nutrition adherence + meal & recipe insights */}
+        <NutritionSectionCard
+          macros={consumedMacros}
+          adherence={mealAdherence}
+          mostEaten={mostEatenRecipes}
+          avgMacros={avgMacros}
+          mostCooked={mostCookedRecipes}
+          inventory={inventorySnapshot}
+        />
 
         <View style={{ height: Spacing.xl }} />
       </ScrollView>
@@ -982,5 +1346,253 @@ const styles = StyleSheet.create({
   },
   statBarSpacer: {
     flex: 1,
+  },
+
+  // ── Nutrition section divider ──────────────────────────────────────────────
+  sectionDivider: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.sm,
+    paddingBottom: Spacing.xs,
+  },
+  sectionDividerText: {
+    fontFamily: Typography.label,
+    fontSize: 10,
+    fontWeight: Typography.weights.bold,
+    letterSpacing: 1.1,
+    textTransform: 'uppercase',
+    color: Colors.textMuted,
+  },
+
+  // ── Macro trend chart ──────────────────────────────────────────────────────
+  macroChartBlock: {
+    marginBottom: Spacing.md,
+  },
+  macroChartHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.xs,
+  },
+  macroChartLabel: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    fontWeight: Typography.weights.semibold,
+    color: Colors.textSecondary,
+  },
+  macroChartValue: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    fontWeight: Typography.weights.bold,
+    color: Colors.textMuted,
+  },
+  macroChartContainer: {
+    height: 56,
+    position: 'relative',
+    marginBottom: Spacing.xs,
+  },
+  macroChartBg: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: Radius.sm,
+  },
+  /** Hairline reference at the top of the chart = 100% of goal */
+  macroGoalLine: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 1,
+    backgroundColor: Colors.line2,
+  },
+  macroBarsLayer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    top: 0,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+  },
+  macroBarCol: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    height: '100%',
+    marginHorizontal: 1,
+  },
+  macroBar: {
+    width: '75%',
+    maxWidth: 10,
+    borderTopLeftRadius: 3,
+    borderTopRightRadius: 3,
+  },
+  macroBarDateLabel: {
+    position: 'absolute',
+    bottom: -14,
+    fontFamily: Typography.body,
+    fontSize: 8,
+    color: Colors.textMuted,
+  },
+  macroGoalAnnotation: {
+    fontFamily: Typography.body,
+    fontSize: 9,
+    color: Colors.textMuted,
+    textAlign: 'right',
+    marginTop: Spacing.lg,
+  },
+
+  // ── Plan adherence row ─────────────────────────────────────────────────────
+  adherenceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: Spacing.sm,
+    gap: Spacing.sm,
+  },
+  adherenceLabel: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    width: 90,
+  },
+  adherenceBar: {
+    flex: 1,
+  },
+
+  // ── Insight subheading ─────────────────────────────────────────────────────
+  insightSubheading: {
+    fontFamily: Typography.label,
+    fontSize: 9,
+    fontWeight: Typography.weights.bold,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    color: Colors.textMuted,
+    marginTop: Spacing.sm,
+    marginBottom: Spacing.xs,
+  },
+
+  // ── Recipe rank list ───────────────────────────────────────────────────────
+  recipeRankList: {
+    gap: Spacing.xs,
+  },
+  recipeRankRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  recipeRankBadge: {
+    width: 20,
+    height: 20,
+    borderRadius: Radius.full,
+    backgroundColor: Colors.clayTint,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  recipeRankBadgeSage: {
+    backgroundColor: Colors.sageTint,
+  },
+  recipeRankNum: {
+    fontFamily: Typography.label,
+    fontSize: 9,
+    fontWeight: Typography.weights.bold,
+    color: Colors.clayDeep,
+  },
+  recipeRankNumSage: {
+    color: Colors.sageDeep,
+  },
+  recipeRankTitle: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    flex: 1,
+  },
+
+  // ── Average macros stat row ────────────────────────────────────────────────
+  avgMacrosRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  avgMacroCell: {
+    flex: 1,
+    alignItems: 'center',
+    backgroundColor: Colors.canvasSunken,
+    borderRadius: Radius.sm,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.xs,
+  },
+  avgMacroValue: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.md,
+    fontWeight: Typography.weights.semibold,
+    color: Colors.clay,
+    lineHeight: 18,
+  },
+  avgMacroUnit: {
+    fontFamily: Typography.label,
+    fontSize: 8,
+    fontWeight: Typography.weights.bold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    color: Colors.textMuted,
+    marginTop: 2,
+  },
+  avgMacroSample: {
+    fontFamily: Typography.body,
+    fontSize: 9,
+    color: Colors.textMuted,
+    marginTop: Spacing.xs,
+    textAlign: 'right',
+  },
+
+  // ── Inventory snapshot ─────────────────────────────────────────────────────
+  inventorySummaryRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+    marginBottom: Spacing.sm,
+  },
+  inventoryStatCell: {
+    flex: 1,
+    backgroundColor: Colors.sageTint,
+    borderRadius: Radius.sm,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.xs,
+    alignItems: 'center',
+  },
+  inventoryStatValue: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.lg,
+    fontWeight: Typography.weights.semibold,
+    color: Colors.sageDeep,
+    lineHeight: 20,
+  },
+  inventoryStatLabel: {
+    fontFamily: Typography.label,
+    fontSize: 8,
+    fontWeight: Typography.weights.bold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    color: Colors.textMuted,
+    marginTop: 2,
+  },
+  inventoryItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: Spacing.xs,
+    gap: Spacing.sm,
+  },
+  inventoryItemTitle: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    flex: 1,
+  },
+  inventoryMoreLabel: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    fontStyle: 'italic',
+    marginTop: Spacing.xs,
   },
 });

--- a/src/screens/__tests__/analyticsHelpers.test.ts
+++ b/src/screens/__tests__/analyticsHelpers.test.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for analyticsHelpers.ts — pure functions, no DB required.
  * Issue #265 — Analytics · strength progression + longer trends & streaks
+ * Issue #267 — Analytics · nutrition adherence + meal & recipe insights
  */
 
 import {
@@ -9,6 +10,10 @@ import {
   progressionSteps,
   KG_PER_CYCLE,
   CYCLE_DAYS,
+  computeGoalAdherenceDays,
+  normaliseMacroSeries,
+  macroChartDateLabel,
+  rollingAverage,
 } from '../analyticsHelpers';
 
 // ─── computeStreaks ───────────────────────────────────────────────────────────
@@ -198,6 +203,129 @@ describe('progressionSteps', () => {
     const steps = progressionSteps(pts);
     expect(steps[0]).toEqual(pts[0]);
     expect(steps[steps.length - 1]).toEqual(pts[pts.length - 1]);
+  });
+});
+
+// ─── computeGoalAdherenceDays ─────────────────────────────────────────────────
+
+describe('computeGoalAdherenceDays', () => {
+  it('returns zeros for empty input', () => {
+    const result = computeGoalAdherenceDays([], 1800, 150);
+    expect(result.calorieAdherence).toBe(0);
+    expect(result.proteinAdherence).toBe(0);
+  });
+
+  it('returns 1 when all days meet both goals', () => {
+    const days = [
+      { date: '2024-01-01', calories: 1900, protein: 160 },
+      { date: '2024-01-02', calories: 2000, protein: 155 },
+    ];
+    const result = computeGoalAdherenceDays(days, 1800, 150);
+    expect(result.calorieAdherence).toBe(1);
+    expect(result.proteinAdherence).toBe(1);
+  });
+
+  it('correctly handles partial adherence', () => {
+    const days = [
+      { date: '2024-01-01', calories: 1900, protein: 160 }, // meets both
+      { date: '2024-01-02', calories: 1500, protein: 160 }, // fails calorie
+      { date: '2024-01-03', calories: 1900, protein: 100 }, // fails protein
+      { date: '2024-01-04', calories: 1500, protein: 100 }, // fails both
+    ];
+    const result = computeGoalAdherenceDays(days, 1800, 150);
+    // 2 out of 4 days meet calorie goal
+    expect(result.calorieAdherence).toBeCloseTo(0.5);
+    // 2 out of 4 days meet protein goal
+    expect(result.proteinAdherence).toBeCloseTo(0.5);
+  });
+
+  it('treats exact goal value as meeting the goal', () => {
+    const days = [{ date: '2024-01-01', calories: 1800, protein: 150 }];
+    const result = computeGoalAdherenceDays(days, 1800, 150);
+    expect(result.calorieAdherence).toBe(1);
+    expect(result.proteinAdherence).toBe(1);
+  });
+});
+
+// ─── normaliseMacroSeries ─────────────────────────────────────────────────────
+
+describe('normaliseMacroSeries', () => {
+  const days = [
+    { date: '2024-01-01', calories: 900, protein: 75 },
+    { date: '2024-01-02', calories: 1800, protein: 150 },
+    { date: '2024-01-03', calories: 2700, protein: 225 }, // exceeds goal
+  ];
+
+  it('normalises calories to [0, 1] relative to goal', () => {
+    const result = normaliseMacroSeries(days, 'calories', 1800);
+    expect(result[0]).toBeCloseTo(0.5);
+    expect(result[1]).toBeCloseTo(1.0);
+    expect(result[2]).toBeCloseTo(1.0); // capped at 1
+  });
+
+  it('normalises protein to [0, 1] relative to goal', () => {
+    const result = normaliseMacroSeries(days, 'protein', 150);
+    expect(result[0]).toBeCloseTo(0.5);
+    expect(result[1]).toBeCloseTo(1.0);
+    expect(result[2]).toBeCloseTo(1.0); // capped at 1
+  });
+
+  it('returns all zeros for goalValue = 0', () => {
+    const result = normaliseMacroSeries(days, 'calories', 0);
+    expect(result).toEqual([0, 0, 0]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(normaliseMacroSeries([], 'calories', 1800)).toEqual([]);
+  });
+});
+
+// ─── macroChartDateLabel ──────────────────────────────────────────────────────
+
+describe('macroChartDateLabel', () => {
+  it('returns label for first item (index 0)', () => {
+    expect(macroChartDateLabel(0, 10, '2024-01-15')).toBe('15/01');
+  });
+
+  it('returns label for last item', () => {
+    expect(macroChartDateLabel(9, 10, '2024-03-31')).toBe('31/03');
+  });
+
+  it('returns empty string for middle items', () => {
+    expect(macroChartDateLabel(5, 10, '2024-02-14')).toBe('');
+  });
+
+  it('returns label for single-item series', () => {
+    expect(macroChartDateLabel(0, 1, '2024-06-01')).toBe('01/06');
+  });
+});
+
+// ─── rollingAverage ───────────────────────────────────────────────────────────
+
+describe('rollingAverage', () => {
+  it('returns empty for empty input', () => {
+    expect(rollingAverage([], 7)).toEqual([]);
+  });
+
+  it('single value is its own average', () => {
+    expect(rollingAverage([42], 7)).toEqual([42]);
+  });
+
+  it('first window uses shorter window', () => {
+    // For a 7-day window, the first value has only 1 element (itself)
+    const result = rollingAverage([10, 20, 30], 7);
+    expect(result[0]).toBeCloseTo(10);
+    expect(result[1]).toBeCloseTo(15);   // (10+20)/2
+    expect(result[2]).toBeCloseTo(20);   // (10+20+30)/3
+  });
+
+  it('full window average is computed correctly', () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8];
+    const result = rollingAverage(values, 7);
+    // Index 6: average of values[0..6] = (1+2+3+4+5+6+7)/7 = 4
+    expect(result[6]).toBeCloseTo(4);
+    // Index 7: average of values[1..7] = (2+3+4+5+6+7+8)/7 ≈ 5
+    expect(result[7]).toBeCloseTo(5);
   });
 });
 

--- a/src/screens/analyticsHelpers.ts
+++ b/src/screens/analyticsHelpers.ts
@@ -5,6 +5,7 @@
  * All functions are side-effect free and fully unit-testable.
  *
  * Issue #265 — Analytics · strength progression + longer trends & streaks
+ * Issue #267 — Analytics · nutrition adherence + meal & recipe insights
  */
 
 // ─────────────────────────────────────────────
@@ -243,4 +244,77 @@ function offsetDate(isoDate: string, days: number): string {
   const d = parseISO(isoDate);
   d.setDate(d.getDate() + days);
   return formatISO(d);
+}
+
+// ─────────────────────────────────────────────
+// Nutrition adherence helpers (#267)
+// ─────────────────────────────────────────────
+
+export interface DailyMacroPoint {
+  date: string;
+  calories: number;
+  protein: number;
+}
+
+/**
+ * Given a list of per-day macro totals from `getConsumedMacrosByDay()`,
+ * compute how many days are at or above the given calorie goal and protein goal.
+ *
+ * Returns a 0–1 fraction for each goal (0 when input is empty).
+ */
+export function computeGoalAdherenceDays(
+  days: DailyMacroPoint[],
+  calorieGoal: number,
+  proteinGoal: number
+): { calorieAdherence: number; proteinAdherence: number } {
+  if (days.length === 0) return { calorieAdherence: 0, proteinAdherence: 0 };
+  const calDays = days.filter((d) => d.calories >= calorieGoal).length;
+  const protDays = days.filter((d) => d.protein >= proteinGoal).length;
+  return {
+    calorieAdherence: calDays / days.length,
+    proteinAdherence: protDays / days.length,
+  };
+}
+
+/**
+ * Normalise a series of daily macro totals to a 0–1 range relative to `goalValue`
+ * for use in a View-based chart (bar heights). A day at or above the goal is 1.0.
+ * Days exceeding the goal are capped at 1.0.
+ *
+ * Returns the same array with each point replaced by its clamped ratio.
+ * Handles goalValue = 0 gracefully (returns all zeros).
+ */
+export function normaliseMacroSeries(
+  days: DailyMacroPoint[],
+  key: 'calories' | 'protein',
+  goalValue: number
+): number[] {
+  if (goalValue <= 0) return days.map(() => 0);
+  return days.map((d) => Math.min(1, d[key] / goalValue));
+}
+
+/**
+ * Build a compact display label for a per-day macro chart.
+ * Returns "dd/MM" for the first and last item; empty string for all others.
+ * Used by the View-based chart to avoid label clutter.
+ */
+export function macroChartDateLabel(index: number, total: number, date: string): string {
+  if (total <= 1) return date.substring(8, 10) + '/' + date.substring(5, 7);
+  if (index === 0 || index === total - 1) {
+    return date.substring(8, 10) + '/' + date.substring(5, 7);
+  }
+  return '';
+}
+
+/**
+ * Compute the 7-day rolling average of a macro series. Returns an array of
+ * the same length; the first min(6, length-1) entries use a shorter window.
+ * Useful for smoothing noisy daily data.
+ */
+export function rollingAverage(values: number[], window: number = 7): number[] {
+  return values.map((_, i) => {
+    const start = Math.max(0, i - window + 1);
+    const slice = values.slice(start, i + 1);
+    return slice.reduce((s, v) => s + v, 0) / slice.length;
+  });
 }


### PR DESCRIPTION
## Summary

Extends `AnalyticsDashboardScreen` with a clearly delineated **Nutrition** section (section-divider header + three Cards) beneath the existing workout analytics. View-based charts only — no new npm dependencies, no charting library.

### What is added

**1. Schema migration v30 — `cook_log`**
Appended as the last entry in `MIGRATIONS` (after v29 `off_cache`):
```sql
CREATE TABLE IF NOT EXISTS cook_log (
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  recipe_id TEXT NOT NULL,
  portions INTEGER NOT NULL,
  date TEXT NOT NULL
);
```
`logCookedMeal()` now also inserts a row into `cook_log` (wrapped in `withTransactionAsync`) so cook history accumulates going forward. Cook history cannot be derived from `meal_inventory` alone because that table only tracks current stock.

**2. Default nutrition goals — `src/nutrition/goals.ts`**
New module exporting `NUTRITION_GOALS = { calories: 1800, protein: 150 }` as clearly-documented defaults. Structured for easy later override from a Settings screen (merge user overrides from `app_state` over these constants).

**3. New aggregate DB queries in `database.ts`**
- `getConsumedMacrosByDay(days)` — per-day calorie/protein/carbs/fat totals from `weekly_meal_plan` where `is_consumed = 1`, joined to `recipe_library`
- `getMealAdherence(days)` — consumed ÷ planned ratio over the window
- `getMostEatenRecipes(limit)` — top N recipes by consumed count
- `getAverageConsumedMacros()` — average per-meal macros across all consumed meals
- `getMostCookedRecipes(limit)` — top N from `cook_log` by total portions
- `getInventorySnapshot()` — current `meal_inventory` snapshot (recipes in stock + total portions)

All functions return plain typed objects and degrade gracefully on empty data.

**4. Pure helpers in `analyticsHelpers.ts`**
- `computeGoalAdherenceDays` — fraction of days meeting calorie/protein goals
- `normaliseMacroSeries` — normalise daily values to 0–1 relative to goal (for chart bars)
- `macroChartDateLabel` — label only first/last points to avoid chart clutter
- `rollingAverage` — 7-day rolling average of a numeric series

**5. Unit tests** — 20 new tests for the four pure helpers (fixture data, no DB), keeping the existing 20 analyticsHelpers tests green.

**6. Analytics screen — Nutrition section**
Three new Cards beneath the workout section:
- **Nutrition adherence** — View-based calorie chart (clay accent) + protein chart (sage accent) each with a hairline reference line at the default goal; plan adherence ProgressBar (consumed ÷ planned %). Graceful empty states.
- **Meal insights** — ranked most-eaten recipes list (title + consumed count Pill) + average per-meal macros stat grid (calories/protein/carbs/fat).
- **Cook history & stock** — most-cooked recipes from `cook_log` with graceful "builds as you cook" empty state until data exists; current inventory snapshot (recipe count + total portions + per-recipe rows).

### Data sources

| Insight | Source | Availability |
|---|---|---|
| Daily macro trend | `weekly_meal_plan` + `recipe_library` | Existing data |
| Plan adherence % | `weekly_meal_plan` | Existing data |
| Most-eaten recipes | `weekly_meal_plan` (is_consumed=1) | Existing data |
| Average macros | `weekly_meal_plan` + `recipe_library` | Existing data |
| Most-cooked recipes | `cook_log` (v30, new) | Builds going forward |
| Inventory snapshot | `meal_inventory` | Existing data |

### Constraints met
- No new npm dependencies
- Migration v30 only — no package.json / app.json / eas.json / babel.config.js changes, so no EAS build gate
- All colors/spacing/typography/radius from `src/theme/tokens.ts` — no raw hex, no magic numbers
- View-based charts only
- `npm run typecheck` passes
- `npm test` passes (139/139, 10 test suites)

Closes #267