### PR TITLE
Reminders · cook-when-empty + weekly cook-day (Unit 3b)

### DIFF
--- a/__mocks__/expo-notifications.js
+++ b/__mocks__/expo-notifications.js
@@ -4,6 +4,7 @@
 
 const SchedulableTriggerInputTypes = {
   DAILY: 'daily',
+  WEEKLY: 'weekly',
   CALENDAR: 'calendar',
   TIME_INTERVAL: 'timeInterval',
   DATE: 'date',
@@ -20,6 +21,7 @@ module.exports = {
 
   // Scheduling
   scheduleNotificationAsync: jest.fn(() => Promise.resolve('stub-notification-id')),
+  presentNotificationAsync: jest.fn(() => Promise.resolve('stub-present-id')),
   cancelScheduledNotificationAsync: jest.fn(() => Promise.resolve()),
   cancelAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve()),
   getAllScheduledNotificationsAsync: jest.fn(() => Promise.resolve([])),

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1518,3 +1518,76 @@ export async function getWorkoutReminderTime(): Promise<string> {
 export async function setWorkoutReminderTime(time: string): Promise<void> {
   await setSetting(SETTING_WORKOUT_REMINDER_TIME, time);
 }
+
+// ── Cooking reminder settings (Unit 3b) ──────────
+
+const SETTING_COOK_WHEN_EMPTY_ENABLED = 'cookWhenEmptyEnabled';
+const SETTING_WEEKLY_COOK_DAY_ENABLED = 'weeklyCookDayEnabled';
+const SETTING_WEEKLY_COOK_DAY = 'weeklyCookDay';
+const SETTING_WEEKLY_COOK_DAY_TIME = 'weeklyCookDayTime';
+const SETTING_COOK_EMPTY_NOTIFIED = 'cookEmptyNotified';
+
+const DEFAULT_WEEKLY_COOK_DAY = 0;        // Sunday
+const DEFAULT_WEEKLY_COOK_DAY_TIME = '10:00';
+
+export async function getCookWhenEmptyEnabled(): Promise<boolean> {
+  const raw = await getSetting(SETTING_COOK_WHEN_EMPTY_ENABLED);
+  return raw === 'true';
+}
+
+export async function setCookWhenEmptyEnabled(enabled: boolean): Promise<void> {
+  await setSetting(SETTING_COOK_WHEN_EMPTY_ENABLED, enabled ? 'true' : 'false');
+}
+
+export async function getWeeklyCookDayEnabled(): Promise<boolean> {
+  const raw = await getSetting(SETTING_WEEKLY_COOK_DAY_ENABLED);
+  return raw === 'true';
+}
+
+export async function setWeeklyCookDayEnabled(enabled: boolean): Promise<void> {
+  await setSetting(SETTING_WEEKLY_COOK_DAY_ENABLED, enabled ? 'true' : 'false');
+}
+
+/** Returns the cook day as 0–6 (0 = Sunday). */
+export async function getWeeklyCookDay(): Promise<number> {
+  const raw = await getSetting(SETTING_WEEKLY_COOK_DAY);
+  if (raw === null) return DEFAULT_WEEKLY_COOK_DAY;
+  const parsed = parseInt(raw, 10);
+  return isNaN(parsed) ? DEFAULT_WEEKLY_COOK_DAY : parsed;
+}
+
+export async function setWeeklyCookDay(day: number): Promise<void> {
+  await setSetting(SETTING_WEEKLY_COOK_DAY, String(day));
+}
+
+export async function getWeeklyCookDayTime(): Promise<string> {
+  const raw = await getSetting(SETTING_WEEKLY_COOK_DAY_TIME);
+  return raw ?? DEFAULT_WEEKLY_COOK_DAY_TIME;
+}
+
+export async function setWeeklyCookDayTime(time: string): Promise<void> {
+  await setSetting(SETTING_WEEKLY_COOK_DAY_TIME, time);
+}
+
+/**
+ * Returns true when the cook-empty notification has already been sent for
+ * the current empty episode (debounce). Reset this via resetCookEmptyNotified()
+ * whenever cooking finishes and inventory is replenished.
+ */
+export async function getCookEmptyNotified(): Promise<boolean> {
+  const raw = await getSetting(SETTING_COOK_EMPTY_NOTIFIED);
+  return raw === 'true';
+}
+
+export async function setCookEmptyNotified(notified: boolean): Promise<void> {
+  await setSetting(SETTING_COOK_EMPTY_NOTIFIED, notified ? 'true' : 'false');
+}
+
+/**
+ * Reset the cook-empty debounce flag so the next inventory-empty episode
+ * can trigger a notification again. Call this after finishCooking() or
+ * logCookedMeal() to mark inventory as replenished.
+ */
+export async function resetCookEmptyNotified(): Promise<void> {
+  await setCookEmptyNotified(false);
+}

--- a/src/screens/CookingTasksScreen.tsx
+++ b/src/screens/CookingTasksScreen.tsx
@@ -30,6 +30,7 @@ import {
   finishCooking,
   deleteCookingTask,
   CookingTaskWithRecipe,
+  resetCookEmptyNotified,
 } from '../db/database';
 import {
   Card,
@@ -338,6 +339,9 @@ export default function CookingTasksScreen() {
         selectedTask.recipe_id,
         selectedTask.servings_to_cook
       );
+      // Inventory just grew — reset the debounce so a fresh empty episode
+      // can trigger a cook-when-empty notification again.
+      await resetCookEmptyNotified();
       setModalVisible(false);
       setSelectedTask(null);
       // Reload the list

--- a/src/screens/MealPrepScreen.tsx
+++ b/src/screens/MealPrepScreen.tsx
@@ -23,7 +23,9 @@ import {
   MealInventoryWithRecipe,
   WeeklyMealPlanItem,
   toISODate,
+  resetCookEmptyNotified,
 } from '../db/database';
+import { checkAndNotifyEmptyInventory } from '../services/notifications';
 import {
   Card,
   Row,
@@ -84,6 +86,10 @@ export default function MealPrepScreen() {
   useFocusEffect(
     useCallback(() => {
       loadData();
+      // Check on focus in case inventory emptied while the screen was away
+      checkAndNotifyEmptyInventory().catch((err) =>
+        console.warn('[MealPrepScreen] checkAndNotifyEmptyInventory failed:', err)
+      );
     }, [])
   );
 
@@ -109,6 +115,9 @@ export default function MealPrepScreen() {
     if (portions <= 0) return;
     try {
       await logCookedMeal(recipe_id, portions);
+      // Inventory just grew — clear the empty-episode debounce flag so the
+      // next time it empties again the user gets a fresh notification.
+      await resetCookEmptyNotified();
       setLogModalVisible(false);
       loadData();
     } catch (err) {
@@ -130,6 +139,9 @@ export default function MealPrepScreen() {
   const handleToggleConsumed = async (planId: number, currentVal: boolean) => {
     try {
       await toggleMealConsumed(planId, !currentVal);
+      // After consuming a meal, check whether inventory is now empty
+      // and nudge the user to cook if so (debounced per empty episode).
+      await checkAndNotifyEmptyInventory();
       loadData();
     } catch (err) {
       logDbError(err);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -25,6 +25,14 @@ import {
   getWorkoutReminderTime,
   setWorkoutReminderEnabled,
   setWorkoutReminderTime,
+  getCookWhenEmptyEnabled,
+  setCookWhenEmptyEnabled,
+  getWeeklyCookDayEnabled,
+  setWeeklyCookDayEnabled,
+  getWeeklyCookDay,
+  setWeeklyCookDay,
+  getWeeklyCookDayTime,
+  setWeeklyCookDayTime,
 } from '../db/database';
 import {
   ensurePermissions,
@@ -43,6 +51,17 @@ interface ReminderState {
   time: string;
   permissionDenied: boolean;
 }
+
+interface CookingReminderState {
+  cookWhenEmptyEnabled: boolean;
+  weeklyCookDayEnabled: boolean;
+  weeklyCookDay: number;       // 0–6 (0 = Sunday)
+  weeklyCookDayTime: string;   // "HH:MM"
+  permissionDenied: boolean;
+}
+
+// Day labels for the weekday chip selector (index = JS weekday 0–6)
+const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
 
 // ─── Time stepper helpers ────────────────────────────────────────────────────
 
@@ -141,24 +160,53 @@ export default function SettingsScreen() {
     permissionDenied: false,
   });
 
+  const [cooking, setCooking] = useState<CookingReminderState>({
+    cookWhenEmptyEnabled: false,
+    weeklyCookDayEnabled: false,
+    weeklyCookDay: 0,
+    weeklyCookDayTime: '10:00',
+    permissionDenied: false,
+  });
+
   // Load persisted settings on focus (same pattern as other screens using useFocusEffect)
   useFocusEffect(
     useCallback(() => {
       let active = true;
       (async () => {
-        const enabled = await getWorkoutReminderEnabled();
-        const time = await getWorkoutReminderTime();
+        const [
+          workoutEnabled,
+          workoutTime,
+          cookWhenEmptyEnabled,
+          weeklyCookDayEnabled,
+          weeklyCookDay,
+          weeklyCookDayTime,
+        ] = await Promise.all([
+          getWorkoutReminderEnabled(),
+          getWorkoutReminderTime(),
+          getCookWhenEmptyEnabled(),
+          getWeeklyCookDayEnabled(),
+          getWeeklyCookDay(),
+          getWeeklyCookDayTime(),
+        ]);
         if (active) {
-          setReminder((prev) => ({ ...prev, enabled, time, permissionDenied: false }));
+          setReminder((prev) => ({ ...prev, enabled: workoutEnabled, time: workoutTime, permissionDenied: false }));
+          setCooking((prev) => ({
+            ...prev,
+            cookWhenEmptyEnabled,
+            weeklyCookDayEnabled,
+            weeklyCookDay,
+            weeklyCookDayTime,
+            permissionDenied: false,
+          }));
         }
       })();
       return () => { active = false; };
     }, [])
   );
 
-  // ── Toggle ──────────────────────────────────────────────────────────────
+  // ── Workout: Toggle ─────────────────────────────────────────────────────
 
-  async function handleToggle(value: boolean) {
+  async function handleWorkoutToggle(value: boolean) {
     if (value) {
       const granted = await ensurePermissions();
       if (!granted) {
@@ -171,9 +219,9 @@ export default function SettingsScreen() {
     await reconcileScheduledNotifications();
   }
 
-  // ── Time adjustments ────────────────────────────────────────────────────
+  // ── Workout: Time adjustments ───────────────────────────────────────────
 
-  async function adjustTime(hourDelta: number, minuteDelta: number) {
+  async function adjustWorkoutTime(hourDelta: number, minuteDelta: number) {
     const { hour, minute } = parseTimeString(reminder.time);
     const newHour = stepHour(hour, hourDelta);
     const newMinute = stepMinute(minute, minuteDelta);
@@ -185,7 +233,61 @@ export default function SettingsScreen() {
     }
   }
 
-  const { hour, minute } = parseTimeString(reminder.time);
+  // ── Cooking: Cook-when-empty toggle ────────────────────────────────────
+
+  async function handleCookWhenEmptyToggle(value: boolean) {
+    if (value) {
+      const granted = await ensurePermissions();
+      if (!granted) {
+        setCooking((prev) => ({ ...prev, permissionDenied: true }));
+        return;
+      }
+    }
+    await setCookWhenEmptyEnabled(value);
+    setCooking((prev) => ({ ...prev, cookWhenEmptyEnabled: value, permissionDenied: false }));
+  }
+
+  // ── Cooking: Weekly cook-day toggle ────────────────────────────────────
+
+  async function handleWeeklyCookDayToggle(value: boolean) {
+    if (value) {
+      const granted = await ensurePermissions();
+      if (!granted) {
+        setCooking((prev) => ({ ...prev, permissionDenied: true }));
+        return;
+      }
+    }
+    await setWeeklyCookDayEnabled(value);
+    setCooking((prev) => ({ ...prev, weeklyCookDayEnabled: value, permissionDenied: false }));
+    await reconcileScheduledNotifications();
+  }
+
+  // ── Cooking: Weekday chip selection ────────────────────────────────────
+
+  async function handleWeekdaySelect(day: number) {
+    await setWeeklyCookDay(day);
+    setCooking((prev) => ({ ...prev, weeklyCookDay: day }));
+    if (cooking.weeklyCookDayEnabled) {
+      await reconcileScheduledNotifications();
+    }
+  }
+
+  // ── Cooking: Cook-day time adjustments ─────────────────────────────────
+
+  async function adjustCookDayTime(hourDelta: number, minuteDelta: number) {
+    const { hour, minute } = parseTimeString(cooking.weeklyCookDayTime);
+    const newHour = stepHour(hour, hourDelta);
+    const newMinute = stepMinute(minute, minuteDelta);
+    const newTime = formatTimeString(newHour, newMinute);
+    await setWeeklyCookDayTime(newTime);
+    setCooking((prev) => ({ ...prev, weeklyCookDayTime: newTime }));
+    if (cooking.weeklyCookDayEnabled) {
+      await reconcileScheduledNotifications();
+    }
+  }
+
+  const { hour: workoutHour, minute: workoutMinute } = parseTimeString(reminder.time);
+  const { hour: cookHour, minute: cookMinute } = parseTimeString(cooking.weeklyCookDayTime);
 
   return (
     <ScrollView
@@ -216,7 +318,7 @@ export default function SettingsScreen() {
           </View>
           <Switch
             value={reminder.enabled}
-            onValueChange={handleToggle}
+            onValueChange={handleWorkoutToggle}
             trackColor={{ false: Colors.canvasSunken, true: Colors.sage }}
             thumbColor={reminder.enabled ? Colors.surface : Colors.textMuted}
             ios_backgroundColor={Colors.canvasSunken}
@@ -242,30 +344,130 @@ export default function SettingsScreen() {
             <View style={styles.timeStepperRow}>
               <TimeStepper
                 label="Hour"
-                value={String(hour).padStart(2, '0')}
-                onDecrement={() => adjustTime(-1, 0)}
-                onIncrement={() => adjustTime(1, 0)}
+                value={String(workoutHour).padStart(2, '0')}
+                onDecrement={() => adjustWorkoutTime(-1, 0)}
+                onIncrement={() => adjustWorkoutTime(1, 0)}
               />
               <Text style={styles.timeSeparator}>:</Text>
               <TimeStepper
                 label="Minute"
-                value={String(minute).padStart(2, '0')}
-                onDecrement={() => adjustTime(0, -1)}
-                onIncrement={() => adjustTime(0, 1)}
+                value={String(workoutMinute).padStart(2, '0')}
+                onDecrement={() => adjustWorkoutTime(0, -1)}
+                onIncrement={() => adjustWorkoutTime(0, 1)}
               />
             </View>
             <Text style={styles.timePreview}>
-              Reminder set for {formatTimeString(hour, minute)}
+              Reminder set for {formatTimeString(workoutHour, workoutMinute)}
             </Text>
           </View>
         )}
       </Card>
 
-      {/*
-       * ── Unit 3b placeholder ───────────────────────────────────────────
-       * Add a cooking-reminder Card here with the same toggle + time-stepper
-       * pattern. Keys: cookingReminderEnabled / cookingReminderTime.
-       */}
+      {/* ── Cooking reminders section (Unit 3b) ─────────────────────── */}
+      <Card style={styles.card}>
+        <View style={styles.sectionLabelRow}>
+          <Ionicons name="restaurant-outline" size={16} color={Colors.clayDeep} />
+          <Text style={[styles.sectionLabel, styles.sectionLabelCooking]}>Cooking reminders</Text>
+        </View>
+
+        {/* Cooking permission denied notice (shared) */}
+        {cooking.permissionDenied && (
+          <View style={styles.noticeRow}>
+            <Ionicons name="information-circle-outline" size={16} color={Colors.clayDeep} />
+            <Text style={styles.noticeText}>
+              Enable notifications in your device settings to receive reminders.
+            </Text>
+          </View>
+        )}
+
+        {/* Cook-when-empty toggle */}
+        <View style={styles.toggleRow}>
+          <View style={styles.toggleTextBlock}>
+            <Text style={styles.toggleTitle}>Cook when stock is empty</Text>
+            <Text style={styles.toggleSubtitle}>
+              Get a nudge when you run out of prepped meals
+            </Text>
+          </View>
+          <Switch
+            value={cooking.cookWhenEmptyEnabled}
+            onValueChange={handleCookWhenEmptyToggle}
+            trackColor={{ false: Colors.canvasSunken, true: Colors.clay }}
+            thumbColor={cooking.cookWhenEmptyEnabled ? Colors.surface : Colors.textMuted}
+            ios_backgroundColor={Colors.canvasSunken}
+            accessibilityLabel="Enable cook-when-empty reminder"
+          />
+        </View>
+
+        <View style={styles.sectionDivider} />
+
+        {/* Weekly cook-day toggle */}
+        <View style={styles.toggleRow}>
+          <View style={styles.toggleTextBlock}>
+            <Text style={styles.toggleTitle}>Weekly cook day</Text>
+            <Text style={styles.toggleSubtitle}>
+              Recurring reminder on your chosen day and time
+            </Text>
+          </View>
+          <Switch
+            value={cooking.weeklyCookDayEnabled}
+            onValueChange={handleWeeklyCookDayToggle}
+            trackColor={{ false: Colors.canvasSunken, true: Colors.clay }}
+            thumbColor={cooking.weeklyCookDayEnabled ? Colors.surface : Colors.textMuted}
+            ios_backgroundColor={Colors.canvasSunken}
+            accessibilityLabel="Enable weekly cook-day reminder"
+          />
+        </View>
+
+        {/* Weekday + time chooser (visible only when weekly cook-day is enabled) */}
+        {cooking.weeklyCookDayEnabled && (
+          <View style={styles.timePicker}>
+            <View style={styles.timePickerDivider} />
+
+            {/* Weekday chip selector */}
+            <Text style={styles.timePickerHeading}>Cook day</Text>
+            <View style={styles.weekdayRow}>
+              {DAY_LABELS.map((label, idx) => {
+                const selected = cooking.weeklyCookDay === idx;
+                return (
+                  <TouchableOpacity
+                    key={label}
+                    style={[styles.weekdayChip, selected && styles.weekdayChipSelected]}
+                    onPress={() => handleWeekdaySelect(idx)}
+                    accessibilityLabel={`Select ${label}`}
+                    accessibilityRole="button"
+                    activeOpacity={0.7}
+                  >
+                    <Text style={[styles.weekdayChipLabel, selected && styles.weekdayChipLabelSelected]}>
+                      {label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            {/* Time stepper */}
+            <Text style={[styles.timePickerHeading, styles.timePickerHeadingSpaced]}>Reminder time</Text>
+            <View style={styles.timeStepperRow}>
+              <TimeStepper
+                label="Hour"
+                value={String(cookHour).padStart(2, '0')}
+                onDecrement={() => adjustCookDayTime(-1, 0)}
+                onIncrement={() => adjustCookDayTime(1, 0)}
+              />
+              <Text style={styles.timeSeparator}>:</Text>
+              <TimeStepper
+                label="Minute"
+                value={String(cookMinute).padStart(2, '0')}
+                onDecrement={() => adjustCookDayTime(0, -1)}
+                onIncrement={() => adjustCookDayTime(0, 1)}
+              />
+            </View>
+            <Text style={styles.timePreview}>
+              Reminder every {DAY_LABELS[cooking.weeklyCookDay]} at {formatTimeString(cookHour, cookMinute)}
+            </Text>
+          </View>
+        )}
+      </Card>
     </ScrollView>
   );
 }
@@ -379,5 +581,46 @@ const styles = StyleSheet.create({
     color: Colors.textMuted,
     textAlign: 'center',
     marginTop: Spacing.lg,
+  },
+
+  // Cooking section overrides
+  sectionLabelCooking: {
+    color: Colors.clayDeep,
+  },
+  sectionDivider: {
+    height: 1,
+    backgroundColor: Colors.line,
+    marginVertical: Spacing.md,
+  },
+
+  // Weekday chip selector
+  weekdayRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: Spacing.xs,
+    marginBottom: Spacing.md,
+  },
+  weekdayChip: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: Radius.sm,
+    backgroundColor: Colors.canvasSunken,
+    alignItems: 'center',
+  },
+  weekdayChipSelected: {
+    backgroundColor: Colors.clayTint,
+  },
+  weekdayChipLabel: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  weekdayChipLabelSelected: {
+    color: Colors.clayDeep,
+  },
+  timePickerHeadingSpaced: {
+    marginTop: Spacing.md,
   },
 });

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -1,11 +1,12 @@
 /**
  * Unit tests for pure helper functions in the notification service.
  *
- * parseTimeString and formatTimeString are stateless and have no native
- * dependencies, so they can be tested directly in Jest's node environment.
+ * parseTimeString, formatTimeString, mapWeekdayToExpo, and shouldNotifyEmpty
+ * are all stateless and have no native dependencies, so they can be tested
+ * directly in Jest's node environment.
  */
 
-import { parseTimeString, formatTimeString } from '../notifications';
+import { parseTimeString, formatTimeString, mapWeekdayToExpo, shouldNotifyEmpty } from '../notifications';
 
 describe('parseTimeString', () => {
   it('parses a standard HH:MM string', () => {
@@ -44,5 +45,49 @@ describe('formatTimeString', () => {
       const { hour, minute } = parseTimeString(t);
       expect(formatTimeString(hour, minute)).toBe(t);
     }
+  });
+});
+
+describe('mapWeekdayToExpo', () => {
+  it('maps Sunday (JS 0) to expo 1', () => {
+    expect(mapWeekdayToExpo(0)).toBe(1);
+  });
+
+  it('maps Saturday (JS 6) to expo 7', () => {
+    expect(mapWeekdayToExpo(6)).toBe(7);
+  });
+
+  it('maps all JS weekdays to expo weekdays (offset by 1)', () => {
+    for (let day = 0; day <= 6; day++) {
+      expect(mapWeekdayToExpo(day)).toBe(day + 1);
+    }
+  });
+
+  it('produces values in the expo range 1–7', () => {
+    for (let day = 0; day <= 6; day++) {
+      const expo = mapWeekdayToExpo(day);
+      expect(expo).toBeGreaterThanOrEqual(1);
+      expect(expo).toBeLessThanOrEqual(7);
+    }
+  });
+});
+
+describe('shouldNotifyEmpty', () => {
+  it('returns true when portions are 0 and not yet notified', () => {
+    expect(shouldNotifyEmpty(0, false)).toBe(true);
+  });
+
+  it('returns false when portions are 0 but already notified (debounce)', () => {
+    expect(shouldNotifyEmpty(0, true)).toBe(false);
+  });
+
+  it('returns false when portions are positive (inventory not empty)', () => {
+    expect(shouldNotifyEmpty(1, false)).toBe(false);
+    expect(shouldNotifyEmpty(5, false)).toBe(false);
+    expect(shouldNotifyEmpty(100, false)).toBe(false);
+  });
+
+  it('returns false when portions are positive even if notified flag is false', () => {
+    expect(shouldNotifyEmpty(3, false)).toBe(false);
   });
 });

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -11,7 +11,12 @@
  *   - cancelWorkoutReminder()
  *   - reconcileScheduledNotifications()
  *
- * Unit 3b can add cooking-reminder equivalents here.
+ * Unit 3b additions:
+ *   - scheduleWeeklyCookDay(day, time)
+ *   - cancelWeeklyCookDay()
+ *   - checkAndNotifyEmptyInventory()
+ *   - mapWeekdayToExpo(day) — maps 0–6 (JS, Sun=0) to 1–7 (expo, Sun=1)
+ *   - reconcileScheduledNotifications() extended to sync weekly cook-day
  */
 
 import * as Notifications from 'expo-notifications';
@@ -21,12 +26,19 @@ import {
   setSetting,
   getWorkoutReminderEnabled,
   getWorkoutReminderTime,
+  getWeeklyCookDayEnabled,
+  getWeeklyCookDay,
+  getWeeklyCookDayTime,
+  getMealInventory,
+  getCookEmptyNotified,
+  setCookEmptyNotified,
 } from '../db/database';
 
 // ─── Internal constants ────────────────────────────────────────────────────
 
 const ANDROID_CHANNEL_ID = 'reminders';
 const WORKOUT_REMINDER_ID_KEY = 'workoutReminderNotificationId';
+const WEEKLY_COOK_DAY_ID_KEY = 'weeklyCookDayNotificationId';
 
 // ─── Foreground display handler ────────────────────────────────────────────
 
@@ -164,6 +176,124 @@ export async function cancelWorkoutReminder(): Promise<void> {
   }
 }
 
+// ─── Weekly cook-day reminder ────────────────────────────────────────────────
+
+/**
+ * Map a JS weekday (0–6, 0 = Sunday) to expo-notifications weekday (1–7, 1 = Sunday).
+ * Exported so it can be unit-tested without any native dependencies.
+ */
+export function mapWeekdayToExpo(day: number): number {
+  // JS: 0=Sun,1=Mon,...,6=Sat → expo: 1=Sun,2=Mon,...,7=Sat
+  return day + 1;
+}
+
+/**
+ * Schedule a weekly repeating cook-day reminder on the given weekday + time.
+ * Cancels any previously scheduled cook-day notification first.
+ *
+ * @param day  0–6 (0 = Sunday)
+ * @param time "HH:MM"
+ */
+export async function scheduleWeeklyCookDay(day: number, time: string): Promise<void> {
+  try {
+    await cancelWeeklyCookDay();
+
+    const { hour, minute } = parseTimeString(time);
+    const weekday = mapWeekdayToExpo(day);
+
+    const id = await Notifications.scheduleNotificationAsync({
+      content: {
+        title: 'Cook day',
+        body: 'Time to restock your meals for the week.',
+        sound: false,
+        ...(Platform.OS === 'android' ? { channelId: ANDROID_CHANNEL_ID } : {}),
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
+        weekday,
+        hour,
+        minute,
+      } as any,
+    });
+
+    await setSetting(WEEKLY_COOK_DAY_ID_KEY, id);
+    console.log(`[Notifications] Weekly cook-day scheduled (weekday ${weekday}, ${time}, id: ${id})`);
+  } catch (err) {
+    console.warn('[Notifications] scheduleWeeklyCookDay failed:', err);
+  }
+}
+
+/**
+ * Cancel the previously scheduled weekly cook-day reminder (if any).
+ */
+export async function cancelWeeklyCookDay(): Promise<void> {
+  try {
+    const id = await getSetting(WEEKLY_COOK_DAY_ID_KEY);
+    if (id) {
+      await Notifications.cancelScheduledNotificationAsync(id);
+      await setSetting(WEEKLY_COOK_DAY_ID_KEY, '');
+      console.log(`[Notifications] Weekly cook-day reminder cancelled (id: ${id})`);
+    }
+  } catch (err) {
+    console.warn('[Notifications] cancelWeeklyCookDay failed:', err);
+  }
+}
+
+// ─── Cook-when-empty nudge ───────────────────────────────────────────────────
+
+/**
+ * Determine whether an immediate "inventory empty" notification should fire.
+ *
+ * Exported as a pure decision helper so it can be unit-tested without
+ * any DB or native calls.
+ *
+ * @param totalPortions   Sum of portions_available across all inventory rows.
+ * @param alreadyNotified Whether the debounce flag is already set.
+ * @returns true when the notification should be presented.
+ */
+export function shouldNotifyEmpty(totalPortions: number, alreadyNotified: boolean): boolean {
+  return totalPortions === 0 && !alreadyNotified;
+}
+
+/**
+ * Check inventory and, when empty and not yet notified in this episode,
+ * present an immediate local notification and set the debounce flag.
+ *
+ * This is an in-app triggered check — there is no background OS scheduling
+ * for this notification type. The caller is responsible for invoking this
+ * at appropriate moments (after consuming a meal, on relevant screen focus).
+ *
+ * The debounce flag (cookEmptyNotified in app_state) is cleared by
+ * resetCookEmptyNotified() when cooking finishes and inventory is replenished,
+ * so each new empty episode produces exactly one notification.
+ */
+export async function checkAndNotifyEmptyInventory(): Promise<void> {
+  try {
+    const enabled = await (await import('../db/database')).getCookWhenEmptyEnabled();
+    if (!enabled) return;
+
+    const inventory = await getMealInventory();
+    const totalPortions = inventory.reduce((sum, item) => sum + item.portions_available, 0);
+    const alreadyNotified = await getCookEmptyNotified();
+
+    if (!shouldNotifyEmpty(totalPortions, alreadyNotified)) return;
+
+    await Notifications.presentNotificationAsync({
+      title: 'Meal stock empty',
+      body: "You're out of prepped meals — time to cook a batch.",
+      sound: false,
+      ...(Platform.OS === 'android' ? { channelId: ANDROID_CHANNEL_ID } : {}),
+    } as any);
+
+    await setCookEmptyNotified(true);
+    console.log('[Notifications] Cook-when-empty notification presented.');
+  } catch (err) {
+    console.warn('[Notifications] checkAndNotifyEmptyInventory failed:', err);
+  }
+}
+
+// ─── Reconcile ───────────────────────────────────────────────────────────────
+
 /**
  * Read persisted settings and bring the OS scheduled notifications into sync.
  *
@@ -175,13 +305,25 @@ export async function cancelWorkoutReminder(): Promise<void> {
  */
 export async function reconcileScheduledNotifications(): Promise<void> {
   try {
-    const enabled = await getWorkoutReminderEnabled();
-    const time = await getWorkoutReminderTime();
+    // Workout reminder
+    const workoutEnabled = await getWorkoutReminderEnabled();
+    const workoutTime = await getWorkoutReminderTime();
 
-    if (enabled) {
-      await scheduleWorkoutReminder(time);
+    if (workoutEnabled) {
+      await scheduleWorkoutReminder(workoutTime);
     } else {
       await cancelWorkoutReminder();
+    }
+
+    // Weekly cook-day reminder
+    const cookDayEnabled = await getWeeklyCookDayEnabled();
+    const cookDay = await getWeeklyCookDay();
+    const cookDayTime = await getWeeklyCookDayTime();
+
+    if (cookDayEnabled) {
+      await scheduleWeeklyCookDay(cookDay, cookDayTime);
+    } else {
+      await cancelWeeklyCookDay();
     }
   } catch (err) {
     console.warn('[Notifications] reconcileScheduledNotifications failed:', err);

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -278,12 +278,23 @@ export async function checkAndNotifyEmptyInventory(): Promise<void> {
 
     if (!shouldNotifyEmpty(totalPortions, alreadyNotified)) return;
 
-    await Notifications.presentNotificationAsync({
-      title: 'Meal stock empty',
-      body: "You're out of prepped meals — time to cook a batch.",
-      sound: false,
-      ...(Platform.OS === 'android' ? { channelId: ANDROID_CHANNEL_ID } : {}),
-    } as any);
+    // Use a 1-second interval trigger to present an immediate notification.
+    // expo-notifications does not expose a "present now" API directly; the
+    // shortest repeatable trigger is TIME_INTERVAL with seconds >= 1 and
+    // repeats: false.
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: 'Meal stock empty',
+        body: "You're out of prepped meals — time to cook a batch.",
+        sound: false,
+        ...(Platform.OS === 'android' ? { channelId: ANDROID_CHANNEL_ID } : {}),
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+        seconds: 1,
+        repeats: false,
+      },
+    });
 
     await setCookEmptyNotified(true);
     console.log('[Notifications] Cook-when-empty notification presented.');


### PR DESCRIPTION
## Summary

Implements Unit 3b of the reminders track, building directly on the 3a notification foundation.

### Two new reminder types

**1. Cook-when-empty nudge (event-driven, in-app)**
When the user's meal inventory drops to zero portions, an immediate local notification fires: "Meal stock empty — You're out of prepped meals, time to cook a batch." A debounce flag (`cookEmptyNotified` in `app_state`) ensures at most one notification per empty episode. The flag is cleared whenever cooking finishes (`finishCooking` in CookingTasksScreen) or a meal is logged (`logCookedMeal` in MealPrepScreen), so the next empty episode gets its own notification.

**Known limitation:** Because the app is offline-only with no background execution capability, this check is purely event-driven inside the app — it fires when a meal is marked consumed and on screen focus of MealPrepScreen. It is not an OS-scheduled background check.

**2. Weekly cook-day (OS-scheduled, repeating)**
A recurring weekly notification on the user's chosen weekday and time, using `SchedulableTriggerInputTypes.WEEKLY` with `{ weekday, hour, minute }`. Expo's weekday range is 1–7 (1 = Sunday); the setting stores 0–6 (JS convention), mapped via `mapWeekdayToExpo()`. The notification id is persisted in `app_state` so it can be cancelled and rescheduled cleanly.

### New settings (all backed by existing `app_state` table — no migration)
- `cookWhenEmptyEnabled` (bool, default false)
- `weeklyCookDayEnabled` (bool, default false)
- `weeklyCookDay` (0–6; default 0 = Sunday)
- `weeklyCookDayTime` ("HH:MM"; default "10:00")

### Files changed
| File | Change |
|---|---|
| `src/db/database.ts` | 4 typed setting getter/setter pairs + `resetCookEmptyNotified()` |
| `src/services/notifications.ts` | `mapWeekdayToExpo`, `shouldNotifyEmpty`, `scheduleWeeklyCookDay`, `cancelWeeklyCookDay`, `checkAndNotifyEmptyInventory`; `reconcileScheduledNotifications` extended |
| `src/screens/SettingsScreen.tsx` | "Cooking reminders" card: cook-when-empty toggle, weekly cook-day toggle, Sun–Sat chip selector, time stepper; Verdure tokens throughout |
| `src/screens/MealPrepScreen.tsx` | `checkAndNotifyEmptyInventory()` after `toggleMealConsumed` + on `useFocusEffect`; `resetCookEmptyNotified()` after `logCookedMeal` |
| `src/screens/CookingTasksScreen.tsx` | `resetCookEmptyNotified()` after `finishCooking` |
| `__mocks__/expo-notifications.js` | Added `WEEKLY` to `SchedulableTriggerInputTypes`, added `presentNotificationAsync` stub |
| `src/services/__tests__/notifications.test.ts` | Unit tests for `mapWeekdayToExpo` (all 7 days, boundary values) and `shouldNotifyEmpty` (empty+unnotified fires, debounce blocks, non-empty blocked) |

### No new dependencies, no schema migration, no EAS build gate
All changes are JS/TS only. Settings persist in the existing `app_state` table.

### Quality gates
- `npm run typecheck` — passes
- `npm test` — 154 tests, 12 suites, all green

Closes #271