### PR TITLE
feat: user-configurable daily nutrition goals (calories + protein)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -21,6 +21,10 @@ import * as SQLite from 'expo-sqlite';
 import { CREATE_SCHEMA_VERSION_TABLE, MIGRATIONS, Exercise } from './schema';
 import { bioForceExercises } from '../../bioForceExercises';
 import { recipes } from '../data/recipes';
+import { NUTRITION_GOALS, NutritionGoals } from '../nutrition/goals';
+
+// Re-export NutritionGoals so screens only need to import from database.ts
+export type { NutritionGoals };
 
 export interface RecipeIngredient {
   name: string;
@@ -1590,4 +1594,45 @@ export async function setCookEmptyNotified(notified: boolean): Promise<void> {
  */
 export async function resetCookEmptyNotified(): Promise<void> {
   await setCookEmptyNotified(false);
+}
+
+// ── Nutrition goal settings (#274) ────────────────────────────────────────────
+
+const SETTING_NUTRITION_GOAL_CALORIES = 'nutritionGoalCalories';
+const SETTING_NUTRITION_GOAL_PROTEIN = 'nutritionGoalProtein';
+
+/**
+ * Read the user's stored nutrition goals from app_state, falling back to
+ * NUTRITION_GOALS defaults for any value that has not been persisted yet.
+ *
+ * Callers (AnalyticsDashboardScreen, SettingsScreen) should call this in
+ * their useFocusEffect / loadData to pick up changes made in Settings.
+ */
+export async function getNutritionGoals(): Promise<NutritionGoals> {
+  const [calRaw, protRaw] = await Promise.all([
+    getSetting(SETTING_NUTRITION_GOAL_CALORIES),
+    getSetting(SETTING_NUTRITION_GOAL_PROTEIN),
+  ]);
+
+  const calories =
+    calRaw !== null && !isNaN(Number(calRaw))
+      ? Number(calRaw)
+      : NUTRITION_GOALS.calories;
+
+  const protein =
+    protRaw !== null && !isNaN(Number(protRaw))
+      ? Number(protRaw)
+      : NUTRITION_GOALS.protein;
+
+  return { calories, protein };
+}
+
+/** Persist the user's daily calorie goal (kcal). */
+export async function setNutritionGoalCalories(kcal: number): Promise<void> {
+  await setSetting(SETTING_NUTRITION_GOAL_CALORIES, String(kcal));
+}
+
+/** Persist the user's daily protein goal (grams). */
+export async function setNutritionGoalProtein(g: number): Promise<void> {
+  await setSetting(SETTING_NUTRITION_GOAL_PROTEIN, String(g));
 }

--- a/src/screens/AnalyticsDashboardScreen.tsx
+++ b/src/screens/AnalyticsDashboardScreen.tsx
@@ -47,6 +47,8 @@ import {
   getAverageConsumedMacros,
   getMostCookedRecipes,
   getInventorySnapshot,
+  getNutritionGoals,
+  type NutritionGoals,
   type DailyMacroTotals,
   type MealAdherenceSummary,
   type EatenRecipeRow,
@@ -606,6 +608,7 @@ function NutritionSectionCard({
   avgMacros,
   mostCooked,
   inventory,
+  nutritionGoals,
 }: {
   macros: DailyMacroTotals[];
   adherence: MealAdherenceSummary;
@@ -613,6 +616,7 @@ function NutritionSectionCard({
   avgMacros: AverageConsumedMacros;
   mostCooked: CookedRecipeRow[];
   inventory: InventorySnapshot;
+  nutritionGoals: NutritionGoals;
 }) {
   const hasConsumedHistory = macros.length > 0;
   const hasMostEaten = mostEaten.length > 0;
@@ -642,7 +646,7 @@ function NutritionSectionCard({
             <MacroTrendChart
               macros={macros}
               macroKey="calories"
-              goal={NUTRITION_GOALS.calories}
+              goal={nutritionGoals.calories}
               label="Calories"
               accentColor={Colors.clay}
             />
@@ -651,7 +655,7 @@ function NutritionSectionCard({
             <MacroTrendChart
               macros={macros}
               macroKey="protein"
-              goal={NUTRITION_GOALS.protein}
+              goal={nutritionGoals.protein}
               label="Protein"
               accentColor={Colors.sage}
             />
@@ -840,6 +844,7 @@ export default function AnalyticsDashboardScreen() {
   const [fastingStreak, setFastingStreak] = useState(0);
 
   // ── Nutrition analytics state ────────────────────────────────────────────────
+  const [nutritionGoals, setNutritionGoals] = useState<NutritionGoals>(NUTRITION_GOALS);
   const [consumedMacros, setConsumedMacros] = useState<DailyMacroTotals[]>([]);
   const [mealAdherence, setMealAdherence] = useState<MealAdherenceSummary>({
     planned: 0,
@@ -961,7 +966,7 @@ export default function AnalyticsDashboardScreen() {
       setConsistencyDots(dots);
 
       // ── Nutrition analytics (#267) ──────────────────────────────────────────
-      const [macrosByDay, adherence, topEaten, avgM, topCooked, invSnapshot] =
+      const [macrosByDay, adherence, topEaten, avgM, topCooked, invSnapshot, storedGoals] =
         await Promise.all([
           getConsumedMacrosByDay(30),
           getMealAdherence(30),
@@ -969,6 +974,7 @@ export default function AnalyticsDashboardScreen() {
           getAverageConsumedMacros(),
           getMostCookedRecipes(5),
           getInventorySnapshot(),
+          getNutritionGoals(),
         ]);
 
       setConsumedMacros(macrosByDay);
@@ -977,6 +983,7 @@ export default function AnalyticsDashboardScreen() {
       setAvgMacros(avgM);
       setMostCookedRecipes(topCooked);
       setInventorySnapshot(invSnapshot);
+      setNutritionGoals(storedGoals);
     } catch (err) {
       console.error('Failed to load analytics', err);
     } finally {
@@ -1063,6 +1070,7 @@ export default function AnalyticsDashboardScreen() {
           avgMacros={avgMacros}
           mostCooked={mostCookedRecipes}
           inventory={inventorySnapshot}
+          nutritionGoals={nutritionGoals}
         />
 
         <View style={{ height: Spacing.xl }} />

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -33,6 +33,9 @@ import {
   setWeeklyCookDay,
   getWeeklyCookDayTime,
   setWeeklyCookDayTime,
+  getNutritionGoals,
+  setNutritionGoalCalories,
+  setNutritionGoalProtein,
 } from '../db/database';
 import {
   ensurePermissions,
@@ -59,6 +62,14 @@ interface CookingReminderState {
   weeklyCookDayTime: string;   // "HH:MM"
   permissionDenied: boolean;
 }
+
+// Clamp bounds for nutrition goal steppers
+const CALORIES_MIN = 500;
+const CALORIES_MAX = 5000;
+const CALORIES_STEP = 50;
+const PROTEIN_MIN = 10;
+const PROTEIN_MAX = 500;
+const PROTEIN_STEP = 5;
 
 // Day labels for the weekday chip selector (index = JS weekday 0–6)
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
@@ -168,6 +179,10 @@ export default function SettingsScreen() {
     permissionDenied: false,
   });
 
+  // Nutrition goals — seeded from NUTRITION_GOALS defaults until DB is loaded
+  const [goalCalories, setGoalCalories] = useState(1800);
+  const [goalProtein, setGoalProtein] = useState(150);
+
   // Load persisted settings on focus (same pattern as other screens using useFocusEffect)
   useFocusEffect(
     useCallback(() => {
@@ -180,6 +195,7 @@ export default function SettingsScreen() {
           weeklyCookDayEnabled,
           weeklyCookDay,
           weeklyCookDayTime,
+          nutritionGoals,
         ] = await Promise.all([
           getWorkoutReminderEnabled(),
           getWorkoutReminderTime(),
@@ -187,6 +203,7 @@ export default function SettingsScreen() {
           getWeeklyCookDayEnabled(),
           getWeeklyCookDay(),
           getWeeklyCookDayTime(),
+          getNutritionGoals(),
         ]);
         if (active) {
           setReminder((prev) => ({ ...prev, enabled: workoutEnabled, time: workoutTime, permissionDenied: false }));
@@ -198,6 +215,8 @@ export default function SettingsScreen() {
             weeklyCookDayTime,
             permissionDenied: false,
           }));
+          setGoalCalories(nutritionGoals.calories);
+          setGoalProtein(nutritionGoals.protein);
         }
       })();
       return () => { active = false; };
@@ -284,6 +303,20 @@ export default function SettingsScreen() {
     if (cooking.weeklyCookDayEnabled) {
       await reconcileScheduledNotifications();
     }
+  }
+
+  // ── Nutrition goals: step handlers ────────────────────────────────────
+
+  async function adjustCalories(delta: number) {
+    const newVal = Math.min(CALORIES_MAX, Math.max(CALORIES_MIN, goalCalories + delta));
+    await setNutritionGoalCalories(newVal);
+    setGoalCalories(newVal);
+  }
+
+  async function adjustProtein(delta: number) {
+    const newVal = Math.min(PROTEIN_MAX, Math.max(PROTEIN_MIN, goalProtein + delta));
+    await setNutritionGoalProtein(newVal);
+    setGoalProtein(newVal);
   }
 
   const { hour: workoutHour, minute: workoutMinute } = parseTimeString(reminder.time);
@@ -468,6 +501,78 @@ export default function SettingsScreen() {
           </View>
         )}
       </Card>
+
+      {/* ── Nutrition goals section (#274) ──────────────────────────── */}
+      <Card style={styles.card}>
+        <View style={styles.sectionLabelRow}>
+          <Ionicons name="nutrition-outline" size={16} color={Colors.clayDeep} />
+          <Text style={[styles.sectionLabel, styles.sectionLabelNutrition]}>Nutrition goals</Text>
+        </View>
+
+        <Text style={styles.nutritionSubtitle}>
+          Daily targets used in the Analytics screen
+        </Text>
+
+        {/* Calories stepper */}
+        <View style={styles.goalStepperRow}>
+          <View style={styles.goalStepperLabelBlock}>
+            <Text style={styles.goalStepperTitle}>Daily calories</Text>
+            <Text style={styles.goalStepperUnit}>kcal / day</Text>
+          </View>
+          <View style={styles.goalStepperControls}>
+            <TouchableOpacity
+              style={styles.goalStepperBtn}
+              onPress={() => adjustCalories(-CALORIES_STEP)}
+              accessibilityLabel="Decrease calorie goal"
+              accessibilityRole="button"
+              activeOpacity={0.7}
+            >
+              <Ionicons name="remove-outline" size={18} color={Colors.clayDeep} />
+            </TouchableOpacity>
+            <Text style={styles.goalStepperValue}>{goalCalories}</Text>
+            <TouchableOpacity
+              style={styles.goalStepperBtn}
+              onPress={() => adjustCalories(CALORIES_STEP)}
+              accessibilityLabel="Increase calorie goal"
+              accessibilityRole="button"
+              activeOpacity={0.7}
+            >
+              <Ionicons name="add-outline" size={18} color={Colors.clayDeep} />
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        <View style={styles.sectionDivider} />
+
+        {/* Protein stepper */}
+        <View style={styles.goalStepperRow}>
+          <View style={styles.goalStepperLabelBlock}>
+            <Text style={styles.goalStepperTitle}>Daily protein</Text>
+            <Text style={styles.goalStepperUnit}>g / day</Text>
+          </View>
+          <View style={styles.goalStepperControls}>
+            <TouchableOpacity
+              style={styles.goalStepperBtn}
+              onPress={() => adjustProtein(-PROTEIN_STEP)}
+              accessibilityLabel="Decrease protein goal"
+              accessibilityRole="button"
+              activeOpacity={0.7}
+            >
+              <Ionicons name="remove-outline" size={18} color={Colors.clayDeep} />
+            </TouchableOpacity>
+            <Text style={styles.goalStepperValue}>{goalProtein}</Text>
+            <TouchableOpacity
+              style={styles.goalStepperBtn}
+              onPress={() => adjustProtein(PROTEIN_STEP)}
+              accessibilityLabel="Increase protein goal"
+              accessibilityRole="button"
+              activeOpacity={0.7}
+            >
+              <Ionicons name="add-outline" size={18} color={Colors.clayDeep} />
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Card>
     </ScrollView>
   );
 }
@@ -622,5 +727,57 @@ const styles = StyleSheet.create({
   },
   timePickerHeadingSpaced: {
     marginTop: Spacing.md,
+  },
+
+  // Nutrition goals section
+  sectionLabelNutrition: {
+    color: Colors.clayDeep,
+  },
+  nutritionSubtitle: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    marginBottom: Spacing.md,
+    lineHeight: Typography.sizes.xs * 1.5,
+  },
+  goalStepperRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.md,
+  },
+  goalStepperLabelBlock: {
+    flex: 1,
+  },
+  goalStepperTitle: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+  },
+  goalStepperUnit: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    marginTop: Spacing.xs,
+  },
+  goalStepperControls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  goalStepperBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: Radius.sm,
+    backgroundColor: Colors.clayTint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  goalStepperValue: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.xl,
+    color: Colors.textPrimary,
+    minWidth: 52,
+    textAlign: 'center',
   },
 });

--- a/src/screens/__tests__/analyticsHelpers.test.ts
+++ b/src/screens/__tests__/analyticsHelpers.test.ts
@@ -245,6 +245,30 @@ describe('computeGoalAdherenceDays', () => {
     expect(result.calorieAdherence).toBe(1);
     expect(result.proteinAdherence).toBe(1);
   });
+
+  it('respects custom goal values (user-configured goals, #274)', () => {
+    const days = [
+      { date: '2024-01-01', calories: 2200, protein: 180 }, // meets custom 2000/160
+      { date: '2024-01-02', calories: 1900, protein: 155 }, // fails calories (< 2000), meets protein
+      { date: '2024-01-03', calories: 2100, protein: 140 }, // meets calories, fails protein (< 160)
+    ];
+    const result = computeGoalAdherenceDays(days, 2000, 160);
+    // Days meeting calorie goal 2000: day1 (2200) + day3 (2100) = 2/3
+    expect(result.calorieAdherence).toBeCloseTo(2 / 3);
+    // Days meeting protein goal 160: day1 (180) + day2 (155 fails, wait: 155 < 160 so fails)
+    // day1 (180 >= 160) + day3 (140 < 160) = 1/3
+    expect(result.proteinAdherence).toBeCloseTo(1 / 3);
+  });
+
+  it('returns 0 adherence when goal is very high and nothing meets it', () => {
+    const days = [
+      { date: '2024-01-01', calories: 1500, protein: 100 },
+      { date: '2024-01-02', calories: 1600, protein: 110 },
+    ];
+    const result = computeGoalAdherenceDays(days, 5000, 500);
+    expect(result.calorieAdherence).toBe(0);
+    expect(result.proteinAdherence).toBe(0);
+  });
 });
 
 // ─── normaliseMacroSeries ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Makes daily calorie and protein targets user-configurable from the Settings screen, persisted via the existing `app_state` KV store — no schema migration needed.

## Changes

### `src/db/database.ts`
- Added `getNutritionGoals()` — reads `nutritionGoalCalories` / `nutritionGoalProtein` keys from `app_state`, falling back to `NUTRITION_GOALS` defaults
- Added `setNutritionGoalCalories(kcal)` and `setNutritionGoalProtein(g)` — typed write accessors
- Re-exports `NutritionGoals` type so screens only import from `database.ts`

### `src/screens/SettingsScreen.tsx`
- Added "Nutrition goals" card below the cooking reminders section
- Calories stepper: ±50 kcal, clamped 500–5000 kcal
- Protein stepper: ±5 g, clamped 10–500 g
- Persists on every button press; loaded via `useFocusEffect`
- Uses Verdure tokens (`Colors.clayTint` / `Colors.clayDeep`) and outline Ionicons throughout

### `src/screens/AnalyticsDashboardScreen.tsx`
- Adds `nutritionGoals` state (initialised from `NUTRITION_GOALS` default)
- Loads stored goals via `getNutritionGoals()` inside `loadData()` (part of the nutrition analytics `Promise.all`)
- `NutritionSectionCard` now receives `nutritionGoals` prop; `MacroTrendChart` `goal` lines reflect the user's stored values

### `src/screens/__tests__/analyticsHelpers.test.ts`
- Two new test cases for `computeGoalAdherenceDays` with custom goal values (2000 kcal / 160 g), confirming the pure helper works correctly regardless of which goal values are passed in

## Test results
- `npm run typecheck` — exit 0 (clean)
- `npm test` — 156 passed, 0 failed (12 test suites)

## Package/config files touched
- None (`package.json`, `app.json`, `eas.json`, `babel.config.js` unchanged)

Closes #274