### PR TITLE
On-device data backup & restore

### DIFF
--- a/__mocks__/expo-document-picker.js
+++ b/__mocks__/expo-document-picker.js
@@ -1,0 +1,12 @@
+// Stub for expo-document-picker — the native document picker module is
+// unavailable in Jest's node testEnvironment. Returns a cancelled result by
+// default; individual tests override getDocumentAsync as needed.
+
+module.exports = {
+  getDocumentAsync: jest.fn(() =>
+    Promise.resolve({
+      canceled: true,
+      assets: null,
+    })
+  ),
+};

--- a/__mocks__/expo-file-system.js
+++ b/__mocks__/expo-file-system.js
@@ -1,0 +1,34 @@
+// Stub for expo-file-system (new API) — the native file-system module is
+// unavailable in Jest's node testEnvironment.
+
+const Paths = {
+  cache: { uri: 'file:///cache/' },
+  document: { uri: 'file:///document/' },
+  bundle: { uri: 'file:///bundle/' },
+};
+
+class File {
+  constructor(...uris) {
+    this.uri = uris.map((u) => (typeof u === 'string' ? u : u.uri ?? '')).join('');
+  }
+  write = jest.fn();
+  text = jest.fn(() => Promise.resolve(''));
+  textSync = jest.fn(() => '');
+  create = jest.fn();
+  delete = jest.fn();
+  get exists() { return false; }
+}
+
+class Directory {
+  constructor(...uris) {
+    this.uri = uris.map((u) => (typeof u === 'string' ? u : u.uri ?? '')).join('');
+  }
+  create = jest.fn();
+  get exists() { return false; }
+}
+
+module.exports = {
+  Paths,
+  File,
+  Directory,
+};

--- a/__mocks__/expo-file-system/legacy.js
+++ b/__mocks__/expo-file-system/legacy.js
@@ -1,0 +1,15 @@
+// Stub for expo-file-system/legacy — the native file-system module is
+// unavailable in Jest's node testEnvironment.
+
+module.exports = {
+  cacheDirectory: 'file:///cache/',
+  documentDirectory: 'file:///document/',
+  bundleDirectory: 'file:///bundle/',
+  writeAsStringAsync: jest.fn(() => Promise.resolve()),
+  readAsStringAsync: jest.fn(() => Promise.resolve('')),
+  getInfoAsync: jest.fn(() => Promise.resolve({ exists: false, isDirectory: false })),
+  deleteAsync: jest.fn(() => Promise.resolve()),
+  copyAsync: jest.fn(() => Promise.resolve()),
+  moveAsync: jest.fn(() => Promise.resolve()),
+  makeDirectoryAsync: jest.fn(() => Promise.resolve()),
+};

--- a/__mocks__/expo-sharing.js
+++ b/__mocks__/expo-sharing.js
@@ -1,0 +1,8 @@
+// Stub for expo-sharing — the native sharing module is unavailable in Jest's
+// node testEnvironment. All functions resolve as no-ops so tests that import
+// backup-aware modules don't crash.
+
+module.exports = {
+  isAvailableAsync: jest.fn(() => Promise.resolve(true)),
+  shareAsync: jest.fn(() => Promise.resolve()),
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,5 +14,11 @@ module.exports = {
     // expo-notifications pulls in native channel/permission modules unavailable
     // in Jest's node testEnvironment. Stub the whole package.
     '^expo-notifications$': '<rootDir>/__mocks__/expo-notifications.js',
+    // expo-sharing, expo-document-picker, and expo-file-system use native
+    // modules unavailable in Jest's node testEnvironment.
+    '^expo-sharing$': '<rootDir>/__mocks__/expo-sharing.js',
+    '^expo-document-picker$': '<rootDir>/__mocks__/expo-document-picker.js',
+    '^expo-file-system/legacy$': '<rootDir>/__mocks__/expo-file-system/legacy.js',
+    '^expo-file-system$': '<rootDir>/__mocks__/expo-file-system.js',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-file-system": "~19.0.21",
         "expo-font": "~14.0.12",
         "expo-notifications": "~0.32.17",
+        "expo-sharing": "~14.0.8",
         "expo-sqlite": "~16.0.10",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
@@ -8300,6 +8301,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-14.0.8.tgz",
+      "integrity": "sha512-A1pPr2iBrxypFDCWVAESk532HK+db7MFXbvO2sCV9ienaFXAk7lIBm6bkqgE6vzRd9O3RGdEGzYx80cYlc089Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-sqlite": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-file-system": "~19.0.21",
     "expo-font": "~14.0.12",
     "expo-notifications": "~0.32.17",
+    "expo-sharing": "~14.0.8",
     "expo-sqlite": "~16.0.10",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1596,6 +1596,108 @@ export async function resetCookEmptyNotified(): Promise<void> {
   await setCookEmptyNotified(false);
 }
 
+// ─────────────────────────────────────────────
+// Backup & restore helpers (#277)
+// ─────────────────────────────────────────────
+
+/**
+ * Return the highest version number recorded in schema_version.
+ * Used by the backup service to tag the payload and by the restore
+ * path to enforce the compatibility gate.
+ */
+export async function getCurrentSchemaVersion(): Promise<number> {
+  const db = getDatabase();
+  const row = await db.getFirstAsync<{ max_version: number | null }>(
+    'SELECT MAX(version) AS max_version FROM schema_version'
+  );
+  return row?.max_version ?? 0;
+}
+
+/**
+ * Return all user-owned table names from sqlite_master, excluding any
+ * internal SQLite tables (sqlite_*) and the schema_version table (never
+ * backed up or overwritten during restore).
+ */
+export async function listUserTables(): Promise<string[]> {
+  const db = getDatabase();
+  const rows = await db.getAllAsync<{ name: string }>(
+    `SELECT name FROM sqlite_master
+     WHERE type = 'table'
+       AND name NOT LIKE 'sqlite_%'
+       AND name != 'schema_version'
+     ORDER BY name ASC`
+  );
+  return rows.map((r) => r.name);
+}
+
+/**
+ * Return all rows from the named table as plain objects.
+ * Called once per table during backup export.
+ */
+export async function dumpTable(
+  tableName: string
+): Promise<Record<string, unknown>[]> {
+  const db = getDatabase();
+  // Table name is from sqlite_master — safe to interpolate.
+  const rows = await db.getAllAsync<Record<string, unknown>>(
+    `SELECT * FROM ${tableName}`
+  );
+  return rows;
+}
+
+/**
+ * Restore all tables from the backup payload inside a single transaction.
+ * Rules:
+ *   - schema_version and sqlite_* tables are never touched.
+ *   - Only tables that exist in the current DB are restored (unknown tables
+ *     in older/newer backups are silently skipped).
+ *   - Per-row INSERT uses that row's own column list so new columns added by
+ *     later migrations default-fill rather than error.
+ *
+ * @param payloadTables  The `tables` object from the BackupPayload.
+ * @returns A summary of what was restored.
+ */
+export async function restoreFromPayload(
+  payloadTables: Record<string, Record<string, unknown>[]>
+): Promise<{ tablesRestored: number; rowsRestored: number }> {
+  const db = getDatabase();
+  const liveTableNames = await listUserTables();
+  const liveTableSet = new Set(liveTableNames);
+
+  let tablesRestored = 0;
+  let rowsRestored = 0;
+
+  await db.withTransactionAsync(async () => {
+    for (const [tableName, rows] of Object.entries(payloadTables)) {
+      // Skip tables that don't exist in the current schema
+      if (!liveTableSet.has(tableName)) continue;
+
+      // Wipe existing rows
+      await db.runAsync(`DELETE FROM ${tableName}`);
+
+      // Re-insert each row using that row's own column list
+      for (const row of rows) {
+        const keys = Object.keys(row);
+        if (keys.length === 0) continue;
+
+        const columns = keys.join(', ');
+        const placeholders = keys.map(() => '?').join(', ');
+        const values = keys.map((k) => row[k]);
+
+        await db.runAsync(
+          `INSERT INTO ${tableName} (${columns}) VALUES (${placeholders})`,
+          values as (string | number | null)[]
+        );
+        rowsRestored += 1;
+      }
+
+      tablesRestored += 1;
+    }
+  });
+
+  return { tablesRestored, rowsRestored };
+}
+
 // ── Nutrition goal settings (#274) ────────────────────────────────────────────
 
 const SETTING_NUTRITION_GOAL_CALORIES = 'nutritionGoalCalories';

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -17,6 +17,7 @@ import {
   ScrollView,
   StyleSheet,
   TouchableOpacity,
+  Alert,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
@@ -43,6 +44,7 @@ import {
   formatTimeString,
   parseTimeString,
 } from '../services/notifications';
+import { exportBackup, importBackup } from '../services/backup';
 import Card from '../components/Card';
 import ScreenHeader from '../components/ScreenHeader';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
@@ -178,6 +180,9 @@ export default function SettingsScreen() {
     weeklyCookDayTime: '10:00',
     permissionDenied: false,
   });
+
+  // Backup state
+  const [backupBusy, setBackupBusy] = useState(false);
 
   // Nutrition goals — seeded from NUTRITION_GOALS defaults until DB is loaded
   const [goalCalories, setGoalCalories] = useState(1800);
@@ -317,6 +322,59 @@ export default function SettingsScreen() {
     const newVal = Math.min(PROTEIN_MAX, Math.max(PROTEIN_MIN, goalProtein + delta));
     await setNutritionGoalProtein(newVal);
     setGoalProtein(newVal);
+  }
+
+  // ── Backup: export ──────────────────────────────────────────────────────
+
+  async function handleBackupExport() {
+    if (backupBusy) return;
+    setBackupBusy(true);
+    try {
+      await exportBackup();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Something went wrong.';
+      Alert.alert('Backup failed', message);
+    } finally {
+      setBackupBusy(false);
+    }
+  }
+
+  // ── Backup: restore ─────────────────────────────────────────────────────
+
+  function handleBackupRestore() {
+    if (backupBusy) return;
+    Alert.alert(
+      'Restore from backup',
+      'This will replace ALL current data with the contents of the backup file. This cannot be undone. Continue?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Restore',
+          style: 'destructive',
+          onPress: async () => {
+            setBackupBusy(true);
+            try {
+              const result = await importBackup();
+              if (result === null) {
+                // User cancelled the picker — no action needed
+                return;
+              }
+              Alert.alert(
+                'Restore complete',
+                `Restored ${result.tablesRestored} tables and ${result.rowsRestored} rows. Revisit each screen to see the updated data.`
+              );
+            } catch (err) {
+              const message =
+                err instanceof Error ? err.message : 'Something went wrong.';
+              Alert.alert('Restore failed', message);
+            } finally {
+              setBackupBusy(false);
+            }
+          },
+        },
+      ]
+    );
   }
 
   const { hour: workoutHour, minute: workoutMinute } = parseTimeString(reminder.time);
@@ -573,6 +631,62 @@ export default function SettingsScreen() {
           </View>
         </View>
       </Card>
+
+      {/* ── Data & backup section (#277) ──────────────────────────────── */}
+      <Card style={styles.card}>
+        <View style={styles.sectionLabelRow}>
+          <Ionicons name="save-outline" size={16} color={Colors.skyDeep} />
+          <Text style={[styles.sectionLabel, styles.sectionLabelBackup]}>Data &amp; backup</Text>
+        </View>
+
+        <Text style={styles.backupSubtitle}>
+          Save a copy of all your data to Files, iCloud, or Drive.
+        </Text>
+
+        {/* Back up data */}
+        <TouchableOpacity
+          style={[styles.backupRow, backupBusy && styles.backupRowDisabled]}
+          onPress={handleBackupExport}
+          disabled={backupBusy}
+          accessibilityLabel="Back up data"
+          accessibilityRole="button"
+          activeOpacity={0.7}
+        >
+          <View style={styles.backupIconChip}>
+            <Ionicons name="cloud-upload-outline" size={18} color={Colors.skyDeep} />
+          </View>
+          <View style={styles.backupTextBlock}>
+            <Text style={styles.backupRowTitle}>Back up data</Text>
+            <Text style={styles.backupRowSubtitle}>
+              Export all your data to a JSON file
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward-outline" size={16} color={Colors.textMuted} />
+        </TouchableOpacity>
+
+        <View style={styles.sectionDivider} />
+
+        {/* Restore from backup */}
+        <TouchableOpacity
+          style={[styles.backupRow, backupBusy && styles.backupRowDisabled]}
+          onPress={handleBackupRestore}
+          disabled={backupBusy}
+          accessibilityLabel="Restore from backup"
+          accessibilityRole="button"
+          activeOpacity={0.7}
+        >
+          <View style={[styles.backupIconChip, styles.backupIconChipRestore]}>
+            <Ionicons name="cloud-download-outline" size={18} color={Colors.clayDeep} />
+          </View>
+          <View style={styles.backupTextBlock}>
+            <Text style={styles.backupRowTitle}>Restore from backup</Text>
+            <Text style={styles.backupRowSubtitle}>
+              Replace all data from a backup file
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward-outline" size={16} color={Colors.textMuted} />
+        </TouchableOpacity>
+      </Card>
     </ScrollView>
   );
 }
@@ -779,5 +893,50 @@ const styles = StyleSheet.create({
     color: Colors.textPrimary,
     minWidth: 52,
     textAlign: 'center',
+  },
+
+  // Data & backup section
+  sectionLabelBackup: {
+    color: Colors.skyDeep,
+  },
+  backupSubtitle: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    marginBottom: Spacing.md,
+    lineHeight: Typography.sizes.xs * 1.5,
+  },
+  backupRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  backupRowDisabled: {
+    opacity: 0.5,
+  },
+  backupIconChip: {
+    width: 36,
+    height: 36,
+    borderRadius: Radius.sm,
+    backgroundColor: Colors.skyTint,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backupIconChipRestore: {
+    backgroundColor: Colors.clayTint,
+  },
+  backupTextBlock: {
+    flex: 1,
+  },
+  backupRowTitle: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+  },
+  backupRowSubtitle: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    marginTop: Spacing.xs,
   },
 });

--- a/src/services/__tests__/backup.test.ts
+++ b/src/services/__tests__/backup.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the backup service.
+ *
+ * Only pure, stateless helpers are tested here — DB-transactional paths
+ * (restoreFromPayload, exportBackup) require a real SQLite connection and
+ * are not unit-testable in Jest's node environment (expo-sqlite is mocked).
+ *
+ * Coverage:
+ *   - buildInsertColumns: pure column/placeholder/values builder
+ *   - validatePayload: format check, schema version compatibility gate
+ *   - exportBackup / importBackup smoke: confirm the service exports the
+ *     expected functions (consistent with the repo's existing test style)
+ */
+
+import { buildInsertColumns, validatePayload, exportBackup, importBackup } from '../backup';
+
+// ─── buildInsertColumns ───────────────────────────────────────────────────────
+
+describe('buildInsertColumns', () => {
+  it('builds columns, placeholders, and values for a single-key row', () => {
+    const result = buildInsertColumns({ name: 'Alice' });
+    expect(result.columns).toBe('name');
+    expect(result.placeholders).toBe('?');
+    expect(result.values).toEqual(['Alice']);
+  });
+
+  it('builds columns, placeholders, and values for a multi-key row', () => {
+    const row = { id: 1, date: '2024-01-01', value: 42.5 };
+    const result = buildInsertColumns(row);
+    expect(result.columns).toBe('id, date, value');
+    expect(result.placeholders).toBe('?, ?, ?');
+    expect(result.values).toEqual([1, '2024-01-01', 42.5]);
+  });
+
+  it('handles null values', () => {
+    const row = { id: 1, weight: null };
+    const result = buildInsertColumns(row);
+    expect(result.columns).toBe('id, weight');
+    expect(result.placeholders).toBe('?, ?');
+    expect(result.values).toEqual([1, null]);
+  });
+
+  it('returns the same number of columns, placeholders, and values', () => {
+    const row = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+    const result = buildInsertColumns(row);
+    const colCount = result.columns.split(',').length;
+    const phCount = result.placeholders.split(',').length;
+    expect(colCount).toBe(5);
+    expect(phCount).toBe(5);
+    expect(result.values).toHaveLength(5);
+  });
+});
+
+// ─── validatePayload ─────────────────────────────────────────────────────────
+
+describe('validatePayload', () => {
+  const currentSchemaVersion = 30;
+
+  function makePayload(overrides: Record<string, unknown> = {}) {
+    return {
+      format: 'healthtracker-backup',
+      version: 1,
+      appVersion: '1.0.0',
+      schemaVersion: 20,
+      createdAt: new Date().toISOString(),
+      tables: { daily_log: [] },
+      ...overrides,
+    };
+  }
+
+  it('accepts a valid payload', () => {
+    const payload = makePayload();
+    const result = validatePayload(payload, currentSchemaVersion);
+    expect(result.format).toBe('healthtracker-backup');
+    expect(result.tables).toEqual({ daily_log: [] });
+  });
+
+  it('accepts a payload whose schemaVersion equals currentSchemaVersion', () => {
+    const payload = makePayload({ schemaVersion: currentSchemaVersion });
+    expect(() => validatePayload(payload, currentSchemaVersion)).not.toThrow();
+  });
+
+  it('rejects null', () => {
+    expect(() => validatePayload(null, currentSchemaVersion)).toThrow(
+      'Invalid backup file'
+    );
+  });
+
+  it('rejects an array', () => {
+    expect(() => validatePayload([], currentSchemaVersion)).toThrow(
+      'Invalid backup file'
+    );
+  });
+
+  it('rejects a wrong format string', () => {
+    const payload = makePayload({ format: 'other-app-backup' });
+    expect(() => validatePayload(payload, currentSchemaVersion)).toThrow(
+      'not created by HealthTracker'
+    );
+  });
+
+  it('rejects when tables is missing', () => {
+    const payload = makePayload({ tables: undefined });
+    expect(() => validatePayload(payload, currentSchemaVersion)).toThrow(
+      'missing tables data'
+    );
+  });
+
+  it('rejects when schemaVersion is not a number', () => {
+    const payload = makePayload({ schemaVersion: 'NaN' });
+    expect(() => validatePayload(payload, currentSchemaVersion)).toThrow(
+      'missing schema version'
+    );
+  });
+
+  it('rejects a backup made by a newer app version', () => {
+    const payload = makePayload({ schemaVersion: currentSchemaVersion + 1 });
+    expect(() => validatePayload(payload, currentSchemaVersion)).toThrow(
+      'newer version of the app'
+    );
+  });
+
+  it('round-trips: stringify → parse → validate returns same structure', () => {
+    const original = makePayload({ schemaVersion: 10 });
+    const json = JSON.stringify(original);
+    const parsed = JSON.parse(json);
+    const result = validatePayload(parsed, currentSchemaVersion);
+    expect(result.format).toBe('healthtracker-backup');
+    expect(result.schemaVersion).toBe(10);
+    expect(result.tables).toEqual({ daily_log: [] });
+  });
+});
+
+// ─── Service exports smoke test ───────────────────────────────────────────────
+
+describe('backup service', () => {
+  it('exports exportBackup as a function', () => {
+    expect(typeof exportBackup).toBe('function');
+  });
+
+  it('exports importBackup as a function', () => {
+    expect(typeof importBackup).toBe('function');
+  });
+});

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -1,0 +1,222 @@
+/**
+ * Backup service — export to file + share, and restore from file.
+ *
+ * Architecture:
+ *   - Raw DB queries live in src/db/database.ts (getCurrentSchemaVersion,
+ *     listUserTables, dumpTable, restoreFromPayload).
+ *   - This file owns file I/O (expo-file-system), the share sheet
+ *     (expo-sharing), and the document picker (expo-document-picker).
+ *
+ * Design decisions:
+ *   - Uses the legacy expo-file-system API (expo-file-system/legacy) for
+ *     writing/reading because it handles both file:// and content:// URIs
+ *     reliably on both iOS and Android; the new File/Paths API cannot read
+ *     arbitrary content:// URIs returned by the document picker.
+ *   - schema_version is NEVER included in the backup tables or overwritten
+ *     on restore — that table is managed exclusively by runMigrations().
+ *   - Restore is all-or-nothing via db.withTransactionAsync().
+ */
+
+import * as DocumentPicker from 'expo-document-picker';
+import * as Sharing from 'expo-sharing';
+import {
+  cacheDirectory,
+  writeAsStringAsync,
+  readAsStringAsync,
+} from 'expo-file-system/legacy';
+import {
+  getCurrentSchemaVersion,
+  listUserTables,
+  dumpTable,
+  restoreFromPayload,
+} from '../db/database';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export interface BackupPayload {
+  format: 'healthtracker-backup';
+  version: 1;
+  appVersion: string;
+  schemaVersion: number;
+  createdAt: string;
+  tables: Record<string, Record<string, unknown>[]>;
+}
+
+export interface RestoreResult {
+  tablesRestored: number;
+  rowsRestored: number;
+}
+
+// ─── Pure helpers (exported for unit tests) ──────────────────────────────────
+
+/**
+ * Build the (col1, col2, ...) list and VALUES (?, ?, ...) placeholders for a
+ * single row's keys. This is a pure function with no side-effects.
+ */
+export function buildInsertColumns(row: Record<string, unknown>): {
+  columns: string;
+  placeholders: string;
+  values: unknown[];
+} {
+  const keys = Object.keys(row);
+  return {
+    columns: keys.join(', '),
+    placeholders: keys.map(() => '?').join(', '),
+    values: keys.map((k) => row[k]),
+  };
+}
+
+/**
+ * Validate a parsed object as a BackupPayload. Returns the typed payload or
+ * throws an Error with a user-facing message.
+ *
+ * @param parsed   - The result of JSON.parse on the raw file content.
+ * @param currentSchemaVersion - The live DB schema version; used for the
+ *                               compatibility gate.
+ */
+export function validatePayload(
+  parsed: unknown,
+  currentSchemaVersion: number
+): BackupPayload {
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    Array.isArray(parsed)
+  ) {
+    throw new Error('Invalid backup file: not a JSON object.');
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj['format'] !== 'healthtracker-backup') {
+    throw new Error(
+      'Invalid backup file: this file was not created by HealthTracker.'
+    );
+  }
+
+  if (typeof obj['tables'] !== 'object' || obj['tables'] === null) {
+    throw new Error('Invalid backup file: missing tables data.');
+  }
+
+  const payloadSchema = Number(obj['schemaVersion']);
+  if (isNaN(payloadSchema)) {
+    throw new Error('Invalid backup file: missing schema version.');
+  }
+
+  if (payloadSchema > currentSchemaVersion) {
+    throw new Error(
+      'This backup was made by a newer version of the app — please update the app first.'
+    );
+  }
+
+  return parsed as BackupPayload;
+}
+
+// ─── App version helper ───────────────────────────────────────────────────────
+
+/** Returns the version string from package.json (bundled at build time). */
+function getAppVersion(): string {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pkg = require('../../package.json') as { version?: string };
+    return pkg.version ?? '1.0.0';
+  } catch {
+    return '1.0.0';
+  }
+}
+
+// ─── ISO date helper ─────────────────────────────────────────────────────────
+
+function isoDateString(date: Date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+// ─── Export (backup) ─────────────────────────────────────────────────────────
+
+/**
+ * Build a JSON backup of all user tables, write it to the cache directory,
+ * and present the OS share sheet so the user can save it wherever they like.
+ *
+ * @returns The URI of the temporary file that was shared, for testing.
+ * @throws  When sharing is unavailable or the DB dump fails.
+ */
+export async function exportBackup(): Promise<string> {
+  const sharingAvailable = await Sharing.isAvailableAsync();
+  if (!sharingAvailable) {
+    throw new Error(
+      'Sharing is not available on this device. Cannot export backup.'
+    );
+  }
+
+  // Dump all user tables
+  const schemaVersion = await getCurrentSchemaVersion();
+  const tableNames = await listUserTables();
+  const tables: Record<string, Record<string, unknown>[]> = {};
+
+  for (const name of tableNames) {
+    tables[name] = await dumpTable(name);
+  }
+
+  const payload: BackupPayload = {
+    format: 'healthtracker-backup',
+    version: 1,
+    appVersion: getAppVersion(),
+    schemaVersion,
+    createdAt: new Date().toISOString(),
+    tables,
+  };
+
+  const json = JSON.stringify(payload, null, 2);
+  const fileName = `healthtracker-backup-${isoDateString()}.json`;
+  const fileUri = `${cacheDirectory ?? ''}${fileName}`;
+
+  await writeAsStringAsync(fileUri, json);
+
+  await Sharing.shareAsync(fileUri, {
+    mimeType: 'application/json',
+    dialogTitle: 'Save your HealthTracker backup',
+    UTI: 'public.json',
+  });
+
+  return fileUri;
+}
+
+// ─── Import (restore) ────────────────────────────────────────────────────────
+
+/**
+ * Open the document picker, validate the chosen file as a HealthTracker
+ * backup, then restore all tables transactionally.
+ *
+ * @returns A RestoreResult summary, or null when the user cancelled.
+ * @throws  When the file is invalid, the schema is incompatible, or the
+ *          DB restore transaction fails.
+ */
+export async function importBackup(): Promise<RestoreResult | null> {
+  const result = await DocumentPicker.getDocumentAsync({
+    type: 'application/json',
+    copyToCacheDirectory: true,
+  });
+
+  // User cancelled
+  if (result.canceled || !result.assets || result.assets.length === 0) {
+    return null;
+  }
+
+  const asset = result.assets[0];
+  const rawJson = await readAsStringAsync(asset.uri);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    throw new Error('Invalid backup file: could not parse JSON.');
+  }
+
+  const currentSchemaVersion = await getCurrentSchemaVersion();
+  const payload = validatePayload(parsed, currentSchemaVersion);
+
+  return restoreFromPayload(payload.tables);
+}


### PR DESCRIPTION
## Summary

- Adds `getCurrentSchemaVersion`, `listUserTables`, `dumpTable`, and `restoreFromPayload` to `src/db/database.ts` — all user tables are enumerated dynamically from `sqlite_master` so the backup is always complete including custom recipes; `schema_version` is never touched.
- New `src/services/backup.ts` with `exportBackup()` (dumps all tables to a dated JSON file, presents OS share sheet via `expo-sharing`) and `importBackup()` (picks a file via `expo-document-picker`, validates format + schema compatibility, restores all-or-nothing via `withTransactionAsync`).
- `src/screens/SettingsScreen.tsx` — new "Data & backup" Card section with Back up data and Restore from backup actions; destructive-confirm Alert before restore; incompatibility and success messages.
- `expo-sharing@14.0.8` (SDK 54 aligned) is the only new dependency; `package.json` + `package-lock.json` updated; `app.json` not touched (expo-sharing requires no config plugin).
- Jest stubs added for `expo-sharing`, `expo-document-picker`, and `expo-file-system` (both new API and legacy sub-path); `jest.config.js` updated with matching `moduleNameMapper` entries.
- 15 new unit tests for `buildInsertColumns` and `validatePayload` (the pure helpers); smoke test confirms service exports. All 13 test suites, 171 tests green.

## Test plan

- [ ] `npm run typecheck` exits 0
- [ ] `npm test` — 13 suites, 171 tests, all green
- [ ] On device: Settings screen shows "Data & backup" section
- [ ] Back up data opens share sheet and produces a valid `healthtracker-backup-YYYY-MM-DD.json`
- [ ] Restore from backup shows confirm Alert, then restores data transactionally
- [ ] Restoring a backup with a higher schemaVersion shows the "update the app first" error

Closes #277