### PR TITLE
feat(personal-metrics): daily hydration tracking + body measurements

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1843,3 +1843,194 @@ export async function getLatestBodyWeight(): Promise<number | null> {
   );
   return row?.body_weight ?? null;
 }
+
+// ── Hydration settings (v31) ──────────────────────────────────────────────────
+
+const SETTING_HYDRATION_GOAL_ML = 'hydrationGoalMl';
+const DEFAULT_HYDRATION_GOAL_ML = 2000;
+
+/**
+ * Read the user's daily hydration goal in ml from app_state.
+ * Defaults to 2000 ml when not yet set.
+ */
+export async function getHydrationGoal(): Promise<number> {
+  const raw = await getSetting(SETTING_HYDRATION_GOAL_ML);
+  if (raw !== null && !isNaN(Number(raw))) return Number(raw);
+  return DEFAULT_HYDRATION_GOAL_ML;
+}
+
+/** Persist the user's daily hydration goal in ml. */
+export async function setHydrationGoal(ml: number): Promise<void> {
+  await setSetting(SETTING_HYDRATION_GOAL_ML, String(ml));
+}
+
+// ── Hydration CRUD (water_ml column on daily_log, migration v31) ──────────────
+
+/**
+ * Return today's logged water total for the given date key (YYYY-MM-DD).
+ * Returns 0 when the row doesn't exist or water_ml has not been set.
+ */
+export async function getWaterForDay(dateKey: string): Promise<number> {
+  const db = getDatabase();
+  const row = await db.getFirstAsync<{ water_ml: number }>(
+    'SELECT water_ml FROM daily_log WHERE date = ?',
+    [dateKey]
+  );
+  return row?.water_ml ?? 0;
+}
+
+/**
+ * Increment (or decrement) the water total for `dateKey` by `ml`.
+ * The result is clamped to a minimum of 0 — it never goes negative.
+ *
+ * Upsert-safe: if no row exists for the date (e.g. outside the rolling
+ * window) it inserts one with water_ml = max(0, ml).
+ */
+export async function addWater(dateKey: string, ml: number): Promise<void> {
+  const db = getDatabase();
+  await db.runAsync(
+    `UPDATE daily_log SET water_ml = MAX(0, water_ml + ?) WHERE date = ?`,
+    [ml, dateKey]
+  );
+}
+
+/**
+ * Overwrite the water total for `dateKey` to exactly `ml` (clamped ≥ 0).
+ */
+export async function setWaterForDay(dateKey: string, ml: number): Promise<void> {
+  const db = getDatabase();
+  const clamped = Math.max(0, ml);
+  await db.runAsync(
+    `UPDATE daily_log SET water_ml = ? WHERE date = ?`,
+    [clamped, dateKey]
+  );
+}
+
+/**
+ * Return water_ml for each day in the given date range, ordered ascending.
+ * Days with no row (outside the rolling window) are omitted.
+ *
+ * @param sinceDateKey - Earliest date to include (YYYY-MM-DD).
+ */
+export async function getWaterHistory(
+  sinceDateKey: string
+): Promise<{ date: string; water_ml: number }[]> {
+  const db = getDatabase();
+  const rows = await db.getAllAsync<{ date: string; water_ml: number }>(
+    'SELECT date, water_ml FROM daily_log WHERE date >= ? ORDER BY date ASC',
+    [sinceDateKey]
+  );
+  return rows;
+}
+
+// ── Body measurements CRUD (body_measurements table, migration v32) ───────────
+
+/** A single body-measurement record (one row per date). */
+export interface BodyMeasurement {
+  id: number;
+  date: string;
+  waist_cm: number | null;
+  chest_cm: number | null;
+  hips_cm: number | null;
+  thigh_cm: number | null;
+  arm_cm: number | null;
+}
+
+type MeasurementInput = {
+  waist_cm?: number | null;
+  chest_cm?: number | null;
+  hips_cm?: number | null;
+  thigh_cm?: number | null;
+  arm_cm?: number | null;
+};
+
+/**
+ * Upsert a body-measurement entry for `date`.
+ *
+ * If no row exists for that date, inserts a new one with only the provided
+ * fields set (others stay NULL).  If a row already exists, updates only the
+ * non-undefined fields so previous measurements are preserved.
+ *
+ * @param date   - YYYY-MM-DD date key.
+ * @param fields - Partial measurement object; undefined fields are ignored.
+ */
+export async function logBodyMeasurement(
+  date: string,
+  fields: MeasurementInput
+): Promise<void> {
+  const db = getDatabase();
+  const existing = await db.getFirstAsync<{ id: number }>(
+    'SELECT id FROM body_measurements WHERE date = ?',
+    [date]
+  );
+
+  if (!existing) {
+    // Insert — only supply provided fields; missing ones default to NULL
+    await db.runAsync(
+      `INSERT INTO body_measurements (date, waist_cm, chest_cm, hips_cm, thigh_cm, arm_cm)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        date,
+        fields.waist_cm ?? null,
+        fields.chest_cm ?? null,
+        fields.hips_cm ?? null,
+        fields.thigh_cm ?? null,
+        fields.arm_cm ?? null,
+      ]
+    );
+    return;
+  }
+
+  // Update — only the explicitly provided (non-undefined) fields
+  const setClauses: string[] = [];
+  const values: (number | null)[] = [];
+
+  if (fields.waist_cm !== undefined) { setClauses.push('waist_cm = ?'); values.push(fields.waist_cm ?? null); }
+  if (fields.chest_cm !== undefined) { setClauses.push('chest_cm = ?'); values.push(fields.chest_cm ?? null); }
+  if (fields.hips_cm  !== undefined) { setClauses.push('hips_cm = ?');  values.push(fields.hips_cm  ?? null); }
+  if (fields.thigh_cm !== undefined) { setClauses.push('thigh_cm = ?'); values.push(fields.thigh_cm ?? null); }
+  if (fields.arm_cm   !== undefined) { setClauses.push('arm_cm = ?');   values.push(fields.arm_cm   ?? null); }
+
+  if (setClauses.length === 0) return; // Nothing to update
+
+  await db.runAsync(
+    `UPDATE body_measurements SET ${setClauses.join(', ')} WHERE id = ?`,
+    [...values, existing.id]
+  );
+}
+
+/**
+ * Return all body-measurement rows since `sinceDateKey` (inclusive), ordered
+ * ascending by date.  Returns all rows when `sinceDateKey` is omitted.
+ *
+ * @param sinceDateKey - Optional earliest date (YYYY-MM-DD) to include.
+ */
+export async function getBodyMeasurements(
+  sinceDateKey?: string
+): Promise<BodyMeasurement[]> {
+  const db = getDatabase();
+  let rows: BodyMeasurement[];
+  if (sinceDateKey) {
+    rows = await db.getAllAsync<BodyMeasurement>(
+      'SELECT * FROM body_measurements WHERE date >= ? ORDER BY date ASC',
+      [sinceDateKey]
+    );
+  } else {
+    rows = await db.getAllAsync<BodyMeasurement>(
+      'SELECT * FROM body_measurements ORDER BY date ASC'
+    );
+  }
+  return rows;
+}
+
+/**
+ * Return the single most-recent body-measurement row, or null when no
+ * measurements have been logged yet.
+ */
+export async function getLatestMeasurements(): Promise<BodyMeasurement | null> {
+  const db = getDatabase();
+  const row = await db.getFirstAsync<BodyMeasurement>(
+    'SELECT * FROM body_measurements ORDER BY date DESC LIMIT 1'
+  );
+  return row ?? null;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -577,4 +577,23 @@ export const MIGRATIONS: Migration[] = [
     date TEXT NOT NULL
   );
 ` },
+  // v31: Daily hydration tracking — water_ml stored as running daily total on daily_log.
+  // Date-keyed (one row per YYYY-MM-DD calendar day, same as all other daily_log fields).
+  // DEFAULT 0 so existing rows and new rows created by syncRollingSchedule have a baseline.
+  { version: 31, sql: `ALTER TABLE daily_log ADD COLUMN water_ml INTEGER NOT NULL DEFAULT 0;` },
+  // v32: Body measurements table — one logical entry per date (UNIQUE constraint on date)
+  // so the upsert accessor (logBodyMeasurement) can update only provided fields.
+  // All measurement columns are nullable so the user can log only the measurements they
+  // took on a given day without leaving dummy zeros on the others.
+  { version: 32, sql: `
+  CREATE TABLE IF NOT EXISTS body_measurements (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    date      TEXT    NOT NULL UNIQUE,
+    waist_cm  REAL,
+    chest_cm  REAL,
+    hips_cm   REAL,
+    thigh_cm  REAL,
+    arm_cm    REAL
+  );
+` },
 ];

--- a/src/screens/AnalyticsDashboardScreen.tsx
+++ b/src/screens/AnalyticsDashboardScreen.tsx
@@ -48,6 +48,9 @@ import {
   getMostCookedRecipes,
   getInventorySnapshot,
   getNutritionGoals,
+  getWaterHistory,
+  getBodyMeasurements,
+  getHydrationGoal,
   type NutritionGoals,
   type DailyMacroTotals,
   type MealAdherenceSummary,
@@ -55,6 +58,7 @@ import {
   type AverageConsumedMacros,
   type CookedRecipeRow,
   type InventorySnapshot,
+  type BodyMeasurement,
 } from '../db/database';
 import { addDays as addDaysKey } from '../utils/dates';
 import { Card, ProgressBar, ScreenHeader, Pill } from '../components';
@@ -66,6 +70,11 @@ import {
   KG_PER_CYCLE,
   normaliseMacroSeries,
   macroChartDateLabel,
+  hydrationAverage,
+  hydrationGoalAdherence,
+  measurementDelta,
+  latestMeasurementValue,
+  type HydrationDay,
 } from './analyticsHelpers';
 import { NUTRITION_GOALS } from '../nutrition/goals';
 
@@ -598,6 +607,179 @@ function MacroTrendChart({
   );
 }
 
+// ─── Hydration summary card (#283) ───────────────────────────────────────────
+
+function HydrationSummaryCard({
+  days,
+  goalMl,
+}: {
+  days: HydrationDay[];
+  goalMl: number;
+}) {
+  const avg = hydrationAverage(days);
+  const adherence = hydrationGoalAdherence(days, goalMl);
+  const adherencePct = Math.round(adherence * 100);
+
+  return (
+    <>
+      <View style={styles.sectionDivider}>
+        <Text style={styles.sectionDividerText}>Hydration</Text>
+      </View>
+
+      <Card style={styles.sectionCard}>
+        <View style={styles.cardTitleRow}>
+          <Text style={styles.cardSectionTitle}>7-day hydration</Text>
+          <Text style={styles.cardSectionTrailing}>Last 7 days</Text>
+        </View>
+
+        {days.length === 0 ? (
+          <Text style={styles.emptyText}>No hydration data logged yet.</Text>
+        ) : (
+          <>
+            {/* Metric row */}
+            <View style={styles.hydAvgRow}>
+              <View style={styles.hydAvgCell}>
+                <Text style={styles.hydAvgValue}>{avg}</Text>
+                <Text style={styles.hydAvgUnit}>ml avg / day</Text>
+              </View>
+              <View style={styles.hydAvgCell}>
+                <Text style={[styles.hydAvgValue, { color: adherence >= 1 ? Colors.sageDeep : Colors.skyDeep }]}>
+                  {adherencePct}%
+                </Text>
+                <Text style={styles.hydAvgUnit}>days met goal</Text>
+              </View>
+              <View style={styles.hydAvgCell}>
+                <Text style={styles.hydAvgValue}>{goalMl}</Text>
+                <Text style={styles.hydAvgUnit}>ml goal</Text>
+              </View>
+            </View>
+
+            {/* Goal progress bar */}
+            <View style={styles.hydAdherenceRow}>
+              <Text style={styles.hydAdherenceLabel}>Goal adherence</Text>
+              <ProgressBar
+                progress={adherence}
+                height={7}
+                style={styles.hydAdherenceBar}
+              />
+              <Pill
+                label={`${adherencePct}%`}
+                accent={adherence >= 0.8 ? 'sage' : adherence >= 0.5 ? 'gold' : 'sky'}
+              />
+            </View>
+
+            {/* Per-day bar chart */}
+            <View style={styles.hydChartContainer}>
+              {days.map((d, i) => {
+                const ratio = goalMl > 0 ? Math.min(1, d.water_ml / goalMl) : 0;
+                const heightPct = Math.max(4, ratio * 100);
+                const isLast = i === days.length - 1;
+                return (
+                  <View key={d.date} style={styles.hydBarCol}>
+                    <View
+                      style={[
+                        styles.hydBar,
+                        {
+                          height: `${heightPct}%`,
+                          backgroundColor: isLast ? Colors.sky : Colors.sky + 'AA',
+                        },
+                      ]}
+                    />
+                    {(i === 0 || isLast) && (
+                      <Text style={styles.hydBarLabel}>
+                        {d.date.substring(8, 10)}/{d.date.substring(5, 7)}
+                      </Text>
+                    )}
+                  </View>
+                );
+              })}
+            </View>
+          </>
+        )}
+      </Card>
+    </>
+  );
+}
+
+// ─── Body measurements trend card (#283) ──────────────────────────────────────
+
+function MeasurementsTrendCard({
+  measurements,
+}: {
+  measurements: BodyMeasurement[];
+}) {
+  const FIELDS: Array<{ key: keyof Omit<BodyMeasurement, 'id' | 'date'>; label: string }> = [
+    { key: 'waist_cm',  label: 'Waist'  },
+    { key: 'chest_cm',  label: 'Chest'  },
+    { key: 'hips_cm',   label: 'Hips'   },
+    { key: 'thigh_cm',  label: 'Thigh'  },
+    { key: 'arm_cm',    label: 'Arm'    },
+  ];
+
+  const hasData = measurements.length > 0;
+
+  return (
+    <>
+      <View style={styles.sectionDivider}>
+        <Text style={styles.sectionDividerText}>Body Measurements</Text>
+      </View>
+
+      <Card style={styles.sectionCard}>
+        <View style={styles.cardTitleRow}>
+          <Text style={styles.cardSectionTitle}>Measurement trends</Text>
+          {hasData && (
+            <Text style={styles.cardSectionTrailing}>
+              {measurements.length} {measurements.length === 1 ? 'entry' : 'entries'}
+            </Text>
+          )}
+        </View>
+
+        {!hasData ? (
+          <Text style={styles.emptyText}>
+            Log body measurements on the Today screen to track trends here.
+          </Text>
+        ) : (
+          <View style={styles.measureTrendGrid}>
+            {FIELDS.map(({ key, label }) => {
+              const latest = latestMeasurementValue(measurements, key);
+              const delta = measurementDelta(measurements, key);
+              if (latest === null) return null;
+              const deltaStr =
+                delta === null
+                  ? null
+                  : delta > 0
+                  ? `+${delta.toFixed(1)} cm`
+                  : `${delta.toFixed(1)} cm`;
+              const deltaAccent =
+                delta === null ? Colors.textMuted :
+                delta < 0 ? Colors.sageDeep : Colors.clayDeep;
+
+              return (
+                <View key={key} style={styles.measureTrendCell}>
+                  <Text style={styles.measureTrendLabel}>{label}</Text>
+                  <Text style={styles.measureTrendValue}>{latest.toFixed(1)}</Text>
+                  <Text style={styles.measureTrendUnit}>cm</Text>
+                  {deltaStr != null && (
+                    <Text style={[styles.measureTrendDelta, { color: deltaAccent }]}>
+                      {deltaStr}
+                    </Text>
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        )}
+
+        {hasData && measurements.length > 0 && (
+          <Text style={styles.measureLastDate}>
+            Latest: {measurements[measurements.length - 1].date}
+          </Text>
+        )}
+      </Card>
+    </>
+  );
+}
+
 // ─── Nutrition: Section card ──────────────────────────────────────────────────
 
 function NutritionSectionCard({
@@ -842,6 +1024,13 @@ export default function AnalyticsDashboardScreen() {
   const [workoutCount30, setWorkoutCount30] = useState(0);
   const [fastingStreak, setFastingStreak] = useState(0);
 
+  // ── Hydration analytics state (#283) ────────────────────────────────────────
+  const [hydrationDays, setHydrationDays] = useState<HydrationDay[]>([]);
+  const [hydrationGoalMl, setHydrationGoalMl] = useState(2000);
+
+  // ── Body measurements state (#283) ────────────────────────────────────────
+  const [bodyMeasurements, setBodyMeasurements] = useState<BodyMeasurement[]>([]);
+
   // ── Nutrition analytics state ────────────────────────────────────────────────
   const [nutritionGoals, setNutritionGoals] = useState<NutritionGoals>(NUTRITION_GOALS);
   const [consumedMacros, setConsumedMacros] = useState<DailyMacroTotals[]>([]);
@@ -959,16 +1148,30 @@ export default function AnalyticsDashboardScreen() {
       setConsistencyDots(dots);
 
       // ── Nutrition analytics (#267) ──────────────────────────────────────────
-      const [macrosByDay, adherence, topEaten, avgM, topCooked, invSnapshot, storedGoals] =
-        await Promise.all([
-          getConsumedMacrosByDay(30),
-          getMealAdherence(30),
-          getMostEatenRecipes(5),
-          getAverageConsumedMacros(),
-          getMostCookedRecipes(5),
-          getInventorySnapshot(),
-          getNutritionGoals(),
-        ]);
+      const since7Days = addDaysKey(todayStr, -6); // last 7 days inclusive
+      const [
+        macrosByDay,
+        adherence,
+        topEaten,
+        avgM,
+        topCooked,
+        invSnapshot,
+        storedGoals,
+        waterRows,
+        measurementRows,
+        hydGoal,
+      ] = await Promise.all([
+        getConsumedMacrosByDay(30),
+        getMealAdherence(30),
+        getMostEatenRecipes(5),
+        getAverageConsumedMacros(),
+        getMostCookedRecipes(5),
+        getInventorySnapshot(),
+        getNutritionGoals(),
+        getWaterHistory(since7Days),
+        getBodyMeasurements(),
+        getHydrationGoal(),
+      ]);
 
       setConsumedMacros(macrosByDay);
       setMealAdherence(adherence);
@@ -977,6 +1180,9 @@ export default function AnalyticsDashboardScreen() {
       setMostCookedRecipes(topCooked);
       setInventorySnapshot(invSnapshot);
       setNutritionGoals(storedGoals);
+      setHydrationDays(waterRows);
+      setBodyMeasurements(measurementRows);
+      setHydrationGoalMl(hydGoal);
     } catch (err) {
       console.error('Failed to load analytics', err);
     } finally {
@@ -1065,6 +1271,15 @@ export default function AnalyticsDashboardScreen() {
           inventory={inventorySnapshot}
           nutritionGoals={nutritionGoals}
         />
+
+        {/* Hydration summary (#283) */}
+        <HydrationSummaryCard
+          days={hydrationDays}
+          goalMl={hydrationGoalMl}
+        />
+
+        {/* Body measurements trend (#283) */}
+        <MeasurementsTrendCard measurements={bodyMeasurements} />
 
         <View style={{ height: Spacing.xl }} />
       </ScrollView>
@@ -1594,6 +1809,136 @@ const styles = StyleSheet.create({
     fontSize: Typography.sizes.xs,
     color: Colors.textMuted,
     fontStyle: 'italic',
+    marginTop: Spacing.xs,
+  },
+
+  // ── Hydration summary card (#283) ──────────────────────────────────────────
+  hydAvgRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  hydAvgCell: {
+    flex: 1,
+    backgroundColor: Colors.skyTint,
+    borderRadius: Radius.sm,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.xs,
+    alignItems: 'center',
+  },
+  hydAvgValue: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.md,
+    fontWeight: Typography.weights.semibold,
+    color: Colors.skyDeep,
+    lineHeight: 18,
+  },
+  hydAvgUnit: {
+    fontFamily: Typography.label,
+    fontSize: 8,
+    fontWeight: Typography.weights.bold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    color: Colors.textMuted,
+    marginTop: 2,
+  },
+  hydAdherenceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  hydAdherenceLabel: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textSecondary,
+    width: 90,
+  },
+  hydAdherenceBar: {
+    flex: 1,
+  },
+  hydChartContainer: {
+    height: 56,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+    backgroundColor: Colors.skyTint,
+    borderRadius: Radius.sm,
+    padding: Spacing.xs,
+    overflow: 'hidden',
+  },
+  hydBarCol: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    height: '100%',
+    marginHorizontal: 1,
+  },
+  hydBar: {
+    width: '80%',
+    maxWidth: 10,
+    borderTopLeftRadius: 3,
+    borderTopRightRadius: 3,
+  },
+  hydBarLabel: {
+    position: 'absolute',
+    bottom: -14,
+    fontFamily: Typography.body,
+    fontSize: 8,
+    color: Colors.textMuted,
+  },
+
+  // ── Body measurements trend card (#283) ───────────────────────────────────
+  measureTrendGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+    marginBottom: Spacing.sm,
+  },
+  measureTrendCell: {
+    flex: 1,
+    minWidth: 56,
+    backgroundColor: Colors.clayTint,
+    borderRadius: Radius.sm,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.xs,
+    alignItems: 'center',
+  },
+  measureTrendLabel: {
+    fontFamily: Typography.label,
+    fontSize: 8,
+    fontWeight: Typography.weights.bold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+    color: Colors.clayDeep,
+    marginBottom: 2,
+  },
+  measureTrendValue: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.md,
+    fontWeight: Typography.weights.semibold,
+    color: Colors.textPrimary,
+    lineHeight: 18,
+  },
+  measureTrendUnit: {
+    fontFamily: Typography.label,
+    fontSize: 8,
+    fontWeight: Typography.weights.bold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.3,
+    color: Colors.textMuted,
+    marginTop: 1,
+  },
+  measureTrendDelta: {
+    fontFamily: Typography.title,
+    fontSize: 9,
+    marginTop: 2,
+  },
+  measureLastDate: {
+    fontFamily: Typography.body,
+    fontSize: 9,
+    color: Colors.textMuted,
+    textAlign: 'right',
     marginTop: Spacing.xs,
   },
 });

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -28,6 +28,12 @@ import {
   getTodaysMealsWithRecipe,
   MealPlanWithRecipe,
   toggleMealConsumed,
+  getWaterForDay,
+  addWater,
+  getHydrationGoal,
+  logBodyMeasurement,
+  getLatestMeasurements,
+  type BodyMeasurement,
 } from '../db/database';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
 import {
@@ -211,17 +217,33 @@ export default function DashboardScreen() {
   const [weightInput, setWeightInput] = useState('');
   const [isExtraModalVisible, setExtraModalVisible] = useState(false);
 
+  // Hydration state
+  const [waterMl, setWaterMl] = useState(0);
+  const [hydrationGoal, setHydrationGoal] = useState(2000);
+
+  // Measurements state
+  const [measurementsModalVisible, setMeasurementsModalVisible] = useState(false);
+  const [latestMeasurements, setLatestMeasurements] = useState<BodyMeasurement | null>(null);
+
   const today = toISODate();
 
   const loadToday = useCallback(async () => {
     setLoading(true);
     try {
       await syncRollingSchedule();
-      const data = await getLogByDate(today);
-      const meals = await getTodaysMealsWithRecipe(today);
+      const [data, meals, water, goal, measurements] = await Promise.all([
+        getLogByDate(today),
+        getTodaysMealsWithRecipe(today),
+        getWaterForDay(today),
+        getHydrationGoal(),
+        getLatestMeasurements(),
+      ]);
 
       setEntry(data);
       setTodaysMeals(meals);
+      setWaterMl(water);
+      setHydrationGoal(goal);
+      setLatestMeasurements(measurements);
       if (data?.body_weight) {
         setWeightInput(data.body_weight.toString());
       }
@@ -323,6 +345,35 @@ export default function DashboardScreen() {
       loadToday();
     } catch (err) {
       console.error('toggleMeal error', err);
+    }
+  };
+
+  // ── Hydration handlers ────────────────────────────────────────────────────────
+
+  const handleAddWater = async (ml: number) => {
+    try {
+      await addWater(today, ml);
+      setWaterMl((prev) => Math.max(0, prev + ml));
+    } catch (err) {
+      console.error('addWater error', err);
+    }
+  };
+
+  // ── Measurement handlers ──────────────────────────────────────────────────────
+
+  const handleSaveMeasurements = async (fields: {
+    waist_cm?: number | null;
+    chest_cm?: number | null;
+    hips_cm?: number | null;
+    thigh_cm?: number | null;
+    arm_cm?: number | null;
+  }) => {
+    try {
+      await logBodyMeasurement(today, fields);
+      const updated = await getLatestMeasurements();
+      setLatestMeasurements(updated);
+    } catch (err) {
+      console.error('logBodyMeasurement error', err);
     }
   };
 
@@ -539,6 +590,129 @@ export default function DashboardScreen() {
           </Card>
         </View>
 
+        {/* ── Hydration ────────────────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Card style={styles.sectionHeaderCard}>
+            <View style={styles.sectionHeaderRow}>
+              <IconChip
+                icon={<Ionicons name="water-outline" size={20} color={iconChipIconColor('sky')} />}
+                accent="sky"
+              />
+              <View style={styles.sectionHeaderText}>
+                <Text style={styles.sectionLabel}>HYDRATION</Text>
+                <Text style={styles.sectionSub}>
+                  {waterMl} / {hydrationGoal} ml today
+                </Text>
+              </View>
+              <Pill
+                label={waterMl >= hydrationGoal ? 'Goal met' : `${Math.round((waterMl / hydrationGoal) * 100)}%`}
+                accent={waterMl >= hydrationGoal ? 'sage' : 'sky'}
+              />
+            </View>
+            <ProgressBar
+              progress={Math.min(1, waterMl / Math.max(1, hydrationGoal))}
+              height={6}
+              style={styles.hydrationBar}
+            />
+            <View style={styles.hydrationButtons}>
+              <TouchableOpacity
+                style={styles.hydrationBtn}
+                onPress={() => handleAddWater(250)}
+                activeOpacity={0.75}
+                accessibilityLabel="Add 250 ml"
+                accessibilityRole="button"
+              >
+                <Ionicons name="add-outline" size={14} color={Colors.skyDeep} />
+                <Text style={styles.hydrationBtnLabel}>+250 ml</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.hydrationBtn}
+                onPress={() => handleAddWater(500)}
+                activeOpacity={0.75}
+                accessibilityLabel="Add 500 ml"
+                accessibilityRole="button"
+              >
+                <Ionicons name="add-outline" size={14} color={Colors.skyDeep} />
+                <Text style={styles.hydrationBtnLabel}>+500 ml</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.hydrationBtn, styles.hydrationBtnUndo]}
+                onPress={() => handleAddWater(-250)}
+                activeOpacity={0.75}
+                accessibilityLabel="Remove 250 ml"
+                accessibilityRole="button"
+              >
+                <Ionicons name="remove-outline" size={14} color={Colors.textMuted} />
+                <Text style={[styles.hydrationBtnLabel, styles.hydrationBtnUndoLabel]}>-250 ml</Text>
+              </TouchableOpacity>
+            </View>
+          </Card>
+        </View>
+
+        {/* ── Body Measurements ────────────────────────────────────────────── */}
+        <View style={styles.section}>
+          <Card style={styles.sectionHeaderCard}>
+            <View style={styles.sectionHeaderRow}>
+              <IconChip
+                icon={<Ionicons name="body-outline" size={20} color={iconChipIconColor('clay')} />}
+                accent="clay"
+              />
+              <View style={styles.sectionHeaderText}>
+                <Text style={styles.sectionLabel}>MEASUREMENTS</Text>
+                <Text style={styles.sectionSub}>
+                  {latestMeasurements
+                    ? `Last: ${latestMeasurements.date}`
+                    : 'No measurements logged yet'}
+                </Text>
+              </View>
+              <TouchableOpacity
+                style={styles.measureLogBtn}
+                onPress={() => setMeasurementsModalVisible(true)}
+                activeOpacity={0.75}
+                accessibilityLabel="Log measurements"
+                accessibilityRole="button"
+              >
+                <Ionicons name="add-outline" size={16} color={Colors.clayDeep} />
+                <Text style={styles.measureLogBtnLabel}>Log</Text>
+              </TouchableOpacity>
+            </View>
+            {latestMeasurements && (
+              <View style={styles.measurementPills}>
+                {latestMeasurements.waist_cm != null && (
+                  <View style={styles.measurePill}>
+                    <Text style={styles.measurePillLabel}>Waist</Text>
+                    <Text style={styles.measurePillValue}>{latestMeasurements.waist_cm} cm</Text>
+                  </View>
+                )}
+                {latestMeasurements.chest_cm != null && (
+                  <View style={styles.measurePill}>
+                    <Text style={styles.measurePillLabel}>Chest</Text>
+                    <Text style={styles.measurePillValue}>{latestMeasurements.chest_cm} cm</Text>
+                  </View>
+                )}
+                {latestMeasurements.hips_cm != null && (
+                  <View style={styles.measurePill}>
+                    <Text style={styles.measurePillLabel}>Hips</Text>
+                    <Text style={styles.measurePillValue}>{latestMeasurements.hips_cm} cm</Text>
+                  </View>
+                )}
+                {latestMeasurements.thigh_cm != null && (
+                  <View style={styles.measurePill}>
+                    <Text style={styles.measurePillLabel}>Thigh</Text>
+                    <Text style={styles.measurePillValue}>{latestMeasurements.thigh_cm} cm</Text>
+                  </View>
+                )}
+                {latestMeasurements.arm_cm != null && (
+                  <View style={styles.measurePill}>
+                    <Text style={styles.measurePillLabel}>Arm</Text>
+                    <Text style={styles.measurePillValue}>{latestMeasurements.arm_cm} cm</Text>
+                  </View>
+                )}
+              </View>
+            )}
+          </Card>
+        </View>
+
         {/* ── Extra Workouts ───────────────────────────────────────────────── */}
         <View style={styles.section}>
           <Text style={styles.extraWorkoutsTitle}>Bonuses / Ad-hoc</Text>
@@ -578,7 +752,111 @@ export default function DashboardScreen() {
         onClose={() => setExtraModalVisible(false)}
         onAddWorkout={handleAddExtraWorkout}
       />
+
+      {/* ── Body Measurements Modal ──────────────────────────────────────── */}
+      <MeasurementsModal
+        visible={measurementsModalVisible}
+        onClose={() => setMeasurementsModalVisible(false)}
+        onSave={handleSaveMeasurements}
+        latest={latestMeasurements}
+      />
     </View>
+  );
+}
+
+// ─── Body Measurements Modal ──────────────────────────────────────────────────
+
+function MeasurementsModal({
+  visible,
+  onClose,
+  onSave,
+  latest,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (fields: {
+    waist_cm?: number | null;
+    chest_cm?: number | null;
+    hips_cm?: number | null;
+    thigh_cm?: number | null;
+    arm_cm?: number | null;
+  }) => Promise<void>;
+  latest: BodyMeasurement | null;
+}) {
+  const [waist, setWaist] = useState('');
+  const [chest, setChest] = useState('');
+  const [hips, setHips]   = useState('');
+  const [thigh, setThigh] = useState('');
+  const [arm, setArm]     = useState('');
+
+  // Pre-fill from latest measurements when the modal opens
+  useEffect(() => {
+    if (visible) {
+      setWaist(latest?.waist_cm != null ? String(latest.waist_cm) : '');
+      setChest(latest?.chest_cm != null ? String(latest.chest_cm) : '');
+      setHips(latest?.hips_cm != null  ? String(latest.hips_cm)  : '');
+      setThigh(latest?.thigh_cm != null ? String(latest.thigh_cm) : '');
+      setArm(latest?.arm_cm != null    ? String(latest.arm_cm)   : '');
+    }
+  }, [visible, latest]);
+
+  const parseField = (s: string): number | null => {
+    const v = parseFloat(s);
+    return isNaN(v) || v <= 0 ? null : v;
+  };
+
+  const handleSave = async () => {
+    await onSave({
+      waist_cm: parseField(waist),
+      chest_cm: parseField(chest),
+      hips_cm:  parseField(hips),
+      thigh_cm: parseField(thigh),
+      arm_cm:   parseField(arm),
+    });
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.modalOverlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={styles.modalSheet}>
+          <View style={styles.modalHandle} />
+          <Text style={styles.modalTitle}>Body Measurements</Text>
+          <Text style={styles.modalSubtitle}>Enter values in cm — leave blank to skip</Text>
+          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.modalScroll}>
+            {(
+              [
+                { label: 'Waist', value: waist, onChange: setWaist },
+                { label: 'Chest', value: chest, onChange: setChest },
+                { label: 'Hips',  value: hips,  onChange: setHips  },
+                { label: 'Thigh', value: thigh, onChange: setThigh },
+                { label: 'Arm',   value: arm,   onChange: setArm   },
+              ] as const
+            ).map((field) => (
+              <View key={field.label} style={styles.measureField}>
+                <Text style={styles.measureFieldLabel}>{field.label} (cm)</Text>
+                <TextInput
+                  style={styles.measureFieldInput}
+                  value={field.value}
+                  onChangeText={field.onChange}
+                  keyboardType="decimal-pad"
+                  placeholder="—"
+                  placeholderTextColor={Colors.textMuted}
+                  returnKeyType="next"
+                />
+              </View>
+            ))}
+          </ScrollView>
+          <View style={styles.modalFooter}>
+            <Button title="Cancel" variant="ghost" onPress={onClose} />
+            <Button title="Save" variant="primary" onPress={handleSave} />
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
   );
 }
 
@@ -869,5 +1147,154 @@ const styles = StyleSheet.create({
     letterSpacing: 1.2,
     paddingHorizontal: Spacing.xs,
     paddingBottom: Spacing.xs,
+  },
+
+  // ── Hydration ─────────────────────────────────────────────────────────────
+  hydrationBar: {
+    marginTop: Spacing.md,
+  },
+  hydrationButtons: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.md,
+  },
+  hydrationBtn: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.xs,
+    backgroundColor: Colors.skyTint,
+    borderRadius: Radius.sm,
+    paddingVertical: Spacing.sm,
+    borderWidth: 1,
+    borderColor: Colors.sky,
+  },
+  hydrationBtnLabel: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.xs,
+    color: Colors.skyDeep,
+  },
+  hydrationBtnUndo: {
+    backgroundColor: Colors.canvasSunken,
+    borderColor: Colors.line2,
+  },
+  hydrationBtnUndoLabel: {
+    color: Colors.textMuted,
+  },
+
+  // ── Measurements ──────────────────────────────────────────────────────────
+  measureLogBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    backgroundColor: Colors.clayTint,
+    borderRadius: Radius.sm,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderWidth: 1,
+    borderColor: Colors.clay,
+    alignSelf: 'center',
+  },
+  measureLogBtnLabel: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.xs,
+    color: Colors.clayDeep,
+  },
+  measurementPills: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+    marginTop: Spacing.md,
+  },
+  measurePill: {
+    backgroundColor: Colors.clayTint,
+    borderRadius: Radius.sm,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    alignItems: 'center',
+    minWidth: 64,
+  },
+  measurePillLabel: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs - 1,
+    color: Colors.clayDeep,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  measurePillValue: {
+    fontFamily: Typography.title,
+    fontSize: Typography.sizes.sm,
+    color: Colors.textPrimary,
+    marginTop: 2,
+  },
+
+  // ── Measurements modal ────────────────────────────────────────────────────
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(44,53,46,0.55)',
+    justifyContent: 'flex-end',
+  },
+  modalSheet: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: Radius.xl,
+    borderTopRightRadius: Radius.xl,
+    paddingTop: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing.xl,
+    maxHeight: '75%',
+  },
+  modalHandle: {
+    width: 36,
+    height: 4,
+    backgroundColor: Colors.line2,
+    borderRadius: Radius.full,
+    alignSelf: 'center',
+    marginBottom: Spacing.md,
+  },
+  modalTitle: {
+    fontFamily: Typography.display,
+    fontSize: Typography.sizes.xl,
+    color: Colors.textPrimary,
+    letterSpacing: -0.5,
+    marginBottom: Spacing.xs,
+  },
+  modalSubtitle: {
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    marginBottom: Spacing.md,
+  },
+  modalScroll: {
+    paddingBottom: Spacing.md,
+  },
+  modalFooter: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+    paddingTop: Spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: Colors.line,
+  },
+  measureField: {
+    gap: Spacing.xs,
+    marginBottom: Spacing.md,
+  },
+  measureFieldLabel: {
+    fontFamily: Typography.label,
+    fontSize: Typography.sizes.xs,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  measureFieldInput: {
+    backgroundColor: Colors.background,
+    borderRadius: Radius.sm,
+    borderWidth: 1,
+    borderColor: Colors.line2,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    fontFamily: Typography.body,
+    fontSize: Typography.sizes.md,
+    color: Colors.textPrimary,
   },
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -46,6 +46,8 @@ import {
   setProfileActivityLevel,
   setProfileGoalType,
   getLatestBodyWeight,
+  getHydrationGoal,
+  setHydrationGoal,
   type Sex,
   type ActivityLevel,
   type GoalType,
@@ -86,6 +88,11 @@ const CALORIES_STEP = 50;
 const PROTEIN_MIN = 10;
 const PROTEIN_MAX = 500;
 const PROTEIN_STEP = 5;
+
+// Clamp bounds for hydration goal stepper
+const HYDRATION_MIN = 250;
+const HYDRATION_MAX = 6000;
+const HYDRATION_STEP = 250;
 
 // Day labels for the weekday chip selector (index = JS weekday 0–6)
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
@@ -202,6 +209,9 @@ export default function SettingsScreen() {
   const [goalCalories, setGoalCalories] = useState(1800);
   const [goalProtein, setGoalProtein] = useState(150);
 
+  // Hydration goal (#283)
+  const [hydrationGoalMl, setHydrationGoalMl] = useState(2000);
+
   // User profile state (#281)
   const [profile, setProfile] = useState<UserProfileData>({
     heightCm: null,
@@ -231,6 +241,7 @@ export default function SettingsScreen() {
           nutritionGoals,
           userProfile,
           weight,
+          hydrationGoal,
         ] = await Promise.all([
           getWorkoutReminderEnabled(),
           getWorkoutReminderTime(),
@@ -241,6 +252,7 @@ export default function SettingsScreen() {
           getNutritionGoals(),
           getUserProfile(),
           getLatestBodyWeight(),
+          getHydrationGoal(),
         ]);
         if (active) {
           setReminder((prev) => ({ ...prev, enabled: workoutEnabled, time: workoutTime, permissionDenied: false }));
@@ -254,6 +266,7 @@ export default function SettingsScreen() {
           }));
           setGoalCalories(nutritionGoals.calories);
           setGoalProtein(nutritionGoals.protein);
+          setHydrationGoalMl(hydrationGoal);
           setProfile(userProfile);
           setProfileHeightStr(userProfile.heightCm != null ? String(userProfile.heightCm) : '');
           setProfileAgeStr(userProfile.age != null ? String(userProfile.age) : '');
@@ -358,6 +371,14 @@ export default function SettingsScreen() {
     const newVal = Math.min(PROTEIN_MAX, Math.max(PROTEIN_MIN, goalProtein + delta));
     await setNutritionGoalProtein(newVal);
     setGoalProtein(newVal);
+  }
+
+  // ── Hydration goal: step handler (#283) ───────────────────────────────
+
+  async function adjustHydrationGoal(delta: number) {
+    const newVal = Math.min(HYDRATION_MAX, Math.max(HYDRATION_MIN, hydrationGoalMl + delta));
+    await setHydrationGoal(newVal);
+    setHydrationGoalMl(newVal);
   }
 
   // ── Profile: field save helpers (#281) ────────────────────────────────
@@ -790,6 +811,46 @@ export default function SettingsScreen() {
         </TouchableOpacity>
       </Card>
 
+      {/* ── Hydration goal section (#283) ────────────────────────────── */}
+      <Card style={styles.card}>
+        <View style={styles.sectionLabelRow}>
+          <Ionicons name="water-outline" size={16} color={Colors.skyDeep} />
+          <Text style={[styles.sectionLabel, styles.sectionLabelHydration]}>Hydration goal</Text>
+        </View>
+
+        <Text style={styles.nutritionSubtitle}>
+          Daily water intake target shown in the Today card
+        </Text>
+
+        <View style={styles.goalStepperRow}>
+          <View style={styles.goalStepperLabelBlock}>
+            <Text style={styles.goalStepperTitle}>Daily water goal</Text>
+            <Text style={styles.goalStepperUnit}>ml / day</Text>
+          </View>
+          <View style={styles.goalStepperControls}>
+            <TouchableOpacity
+              style={[styles.goalStepperBtn, styles.goalStepperBtnHydration]}
+              onPress={() => adjustHydrationGoal(-HYDRATION_STEP)}
+              accessibilityLabel="Decrease hydration goal"
+              accessibilityRole="button"
+              activeOpacity={0.7}
+            >
+              <Ionicons name="remove-outline" size={18} color={Colors.skyDeep} />
+            </TouchableOpacity>
+            <Text style={styles.goalStepperValue}>{hydrationGoalMl}</Text>
+            <TouchableOpacity
+              style={[styles.goalStepperBtn, styles.goalStepperBtnHydration]}
+              onPress={() => adjustHydrationGoal(HYDRATION_STEP)}
+              accessibilityLabel="Increase hydration goal"
+              accessibilityRole="button"
+              activeOpacity={0.7}
+            >
+              <Ionicons name="add-outline" size={18} color={Colors.skyDeep} />
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Card>
+
       {/* ── Nutrition goals section (#274) ──────────────────────────── */}
       <Card style={styles.card}>
         <View style={styles.sectionLabelRow}>
@@ -1035,6 +1096,14 @@ const styles = StyleSheet.create({
   // Cooking section overrides
   sectionLabelCooking: {
     color: Colors.clayDeep,
+  },
+
+  // Hydration section overrides (#283)
+  sectionLabelHydration: {
+    color: Colors.skyDeep,
+  },
+  goalStepperBtnHydration: {
+    backgroundColor: Colors.skyTint,
   },
   sectionDivider: {
     height: 1,

--- a/src/screens/__tests__/analyticsHelpers.test.ts
+++ b/src/screens/__tests__/analyticsHelpers.test.ts
@@ -14,6 +14,10 @@ import {
   normaliseMacroSeries,
   macroChartDateLabel,
   rollingAverage,
+  hydrationAverage,
+  hydrationGoalAdherence,
+  measurementDelta,
+  latestMeasurementValue,
 } from '../analyticsHelpers';
 
 // ─── computeStreaks ───────────────────────────────────────────────────────────
@@ -350,6 +354,159 @@ describe('rollingAverage', () => {
     expect(result[6]).toBeCloseTo(4);
     // Index 7: average of values[1..7] = (2+3+4+5+6+7+8)/7 ≈ 5
     expect(result[7]).toBeCloseTo(5);
+  });
+});
+
+// ─── hydrationAverage ────────────────────────────────────────────────────────
+
+describe('hydrationAverage', () => {
+  it('returns 0 for empty input', () => {
+    expect(hydrationAverage([])).toBe(0);
+  });
+
+  it('returns the single value for a one-day series', () => {
+    expect(hydrationAverage([{ date: '2024-01-01', water_ml: 1800 }])).toBe(1800);
+  });
+
+  it('correctly averages multiple days', () => {
+    const days = [
+      { date: '2024-01-01', water_ml: 1000 },
+      { date: '2024-01-02', water_ml: 2000 },
+      { date: '2024-01-03', water_ml: 3000 },
+    ];
+    expect(hydrationAverage(days)).toBe(2000);
+  });
+
+  it('rounds the result to the nearest integer', () => {
+    const days = [
+      { date: '2024-01-01', water_ml: 1000 },
+      { date: '2024-01-02', water_ml: 1001 },
+    ];
+    // Average = 1000.5, rounds to 1001
+    expect(hydrationAverage(days)).toBe(1001);
+  });
+});
+
+// ─── hydrationGoalAdherence ───────────────────────────────────────────────────
+
+describe('hydrationGoalAdherence', () => {
+  it('returns 0 for empty input', () => {
+    expect(hydrationGoalAdherence([], 2000)).toBe(0);
+  });
+
+  it('returns 0 when goalMl is 0', () => {
+    const days = [{ date: '2024-01-01', water_ml: 1500 }];
+    expect(hydrationGoalAdherence(days, 0)).toBe(0);
+  });
+
+  it('returns 1 when all days meet the goal', () => {
+    const days = [
+      { date: '2024-01-01', water_ml: 2000 },
+      { date: '2024-01-02', water_ml: 2500 },
+    ];
+    expect(hydrationGoalAdherence(days, 2000)).toBe(1);
+  });
+
+  it('treats exact goal value as meeting the goal', () => {
+    const days = [{ date: '2024-01-01', water_ml: 2000 }];
+    expect(hydrationGoalAdherence(days, 2000)).toBe(1);
+  });
+
+  it('returns 0 when no days meet the goal', () => {
+    const days = [
+      { date: '2024-01-01', water_ml: 500 },
+      { date: '2024-01-02', water_ml: 750 },
+    ];
+    expect(hydrationGoalAdherence(days, 2000)).toBe(0);
+  });
+
+  it('returns 0.5 when half the days meet the goal', () => {
+    const days = [
+      { date: '2024-01-01', water_ml: 2500 }, // meets
+      { date: '2024-01-02', water_ml: 1000 }, // misses
+    ];
+    expect(hydrationGoalAdherence(days, 2000)).toBeCloseTo(0.5);
+  });
+});
+
+// ─── measurementDelta ────────────────────────────────────────────────────────
+
+describe('measurementDelta', () => {
+  it('returns null for empty input', () => {
+    expect(measurementDelta([], 'waist_cm')).toBeNull();
+  });
+
+  it('returns null when only one non-null value exists', () => {
+    const records = [
+      { waist_cm: 80, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+    ];
+    expect(measurementDelta(records, 'waist_cm')).toBeNull();
+  });
+
+  it('returns null when all values for the field are null', () => {
+    const records = [
+      { waist_cm: null, chest_cm: 90, hips_cm: null, thigh_cm: null, arm_cm: null },
+      { waist_cm: null, chest_cm: 88, hips_cm: null, thigh_cm: null, arm_cm: null },
+    ];
+    expect(measurementDelta(records, 'waist_cm')).toBeNull();
+  });
+
+  it('computes a negative delta (measurement decreased)', () => {
+    const records = [
+      { waist_cm: 90, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+      { waist_cm: 85, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+    ];
+    expect(measurementDelta(records, 'waist_cm')).toBeCloseTo(-5);
+  });
+
+  it('computes a positive delta (measurement increased)', () => {
+    const records = [
+      { waist_cm: null, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: 32 },
+      { waist_cm: null, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: 34 },
+    ];
+    expect(measurementDelta(records, 'arm_cm')).toBeCloseTo(2);
+  });
+
+  it('skips null values when computing first and last', () => {
+    // First non-null is 80, last non-null is 75 (the null in the middle is ignored)
+    const records = [
+      { waist_cm: 80, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+      { waist_cm: null, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+      { waist_cm: 75, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+    ];
+    expect(measurementDelta(records, 'waist_cm')).toBeCloseTo(-5);
+  });
+});
+
+// ─── latestMeasurementValue ───────────────────────────────────────────────────
+
+describe('latestMeasurementValue', () => {
+  it('returns null for empty input', () => {
+    expect(latestMeasurementValue([], 'waist_cm')).toBeNull();
+  });
+
+  it('returns null when all values for the field are null', () => {
+    const records = [
+      { waist_cm: null, chest_cm: 90, hips_cm: null, thigh_cm: null, arm_cm: null },
+    ];
+    expect(latestMeasurementValue(records, 'waist_cm')).toBeNull();
+  });
+
+  it('returns the latest non-null value', () => {
+    const records = [
+      { waist_cm: 85, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+      { waist_cm: null, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+      { waist_cm: 82, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+    ];
+    expect(latestMeasurementValue(records, 'waist_cm')).toBe(82);
+  });
+
+  it('skips trailing nulls and returns the last non-null value', () => {
+    const records = [
+      { waist_cm: 88, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+      { waist_cm: null, chest_cm: null, hips_cm: null, thigh_cm: null, arm_cm: null },
+    ];
+    expect(latestMeasurementValue(records, 'waist_cm')).toBe(88);
   });
 });
 

--- a/src/screens/analyticsHelpers.ts
+++ b/src/screens/analyticsHelpers.ts
@@ -303,3 +303,88 @@ export function rollingAverage(values: number[], window: number = 7): number[] {
     return slice.reduce((s, v) => s + v, 0) / slice.length;
   });
 }
+
+// ─────────────────────────────────────────────
+// Hydration helpers (#283)
+// ─────────────────────────────────────────────
+
+export interface HydrationDay {
+  date: string;
+  water_ml: number;
+}
+
+/**
+ * Compute the average daily water intake over the given array of daily rows.
+ * Returns 0 when the array is empty.
+ *
+ * @param days - Array of {date, water_ml} entries (any date range, any order).
+ */
+export function hydrationAverage(days: HydrationDay[]): number {
+  if (days.length === 0) return 0;
+  const total = days.reduce((sum, d) => sum + d.water_ml, 0);
+  return Math.round(total / days.length);
+}
+
+/**
+ * Compute how many days in the array reached or exceeded `goalMl`.
+ * Returns a 0–1 fraction (0 when the array is empty).
+ *
+ * @param days   - Array of {date, water_ml} entries.
+ * @param goalMl - Daily hydration goal in ml.
+ */
+export function hydrationGoalAdherence(days: HydrationDay[], goalMl: number): number {
+  if (days.length === 0 || goalMl <= 0) return 0;
+  const met = days.filter((d) => d.water_ml >= goalMl).length;
+  return met / days.length;
+}
+
+// ─────────────────────────────────────────────
+// Body-measurement helpers (#283)
+// ─────────────────────────────────────────────
+
+export interface MeasurementPoint {
+  waist_cm: number | null;
+  chest_cm: number | null;
+  hips_cm: number | null;
+  thigh_cm: number | null;
+  arm_cm: number | null;
+}
+
+export type MeasurementField = keyof MeasurementPoint;
+
+/**
+ * Given an ordered array of measurement records (oldest → newest), compute
+ * the change in a specific field from the first non-null value to the last
+ * non-null value.
+ *
+ * Returns null when fewer than two non-null values exist for that field.
+ *
+ * @param records - Array of MeasurementPoint objects, oldest first.
+ * @param field   - Which measurement to compute the delta for.
+ */
+export function measurementDelta(
+  records: MeasurementPoint[],
+  field: MeasurementField
+): number | null {
+  const values = records.map((r) => r[field]).filter((v): v is number => v !== null);
+  if (values.length < 2) return null;
+  return values[values.length - 1] - values[0];
+}
+
+/**
+ * Return the latest non-null value for `field` across the records array,
+ * or null when no records contain a value for that field.
+ *
+ * @param records - Array of MeasurementPoint objects, oldest first.
+ * @param field   - Which field to extract.
+ */
+export function latestMeasurementValue(
+  records: MeasurementPoint[],
+  field: MeasurementField
+): number | null {
+  for (let i = records.length - 1; i >= 0; i--) {
+    const v = records[i][field];
+    if (v !== null) return v;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- **Migration v31**: `ALTER TABLE daily_log ADD COLUMN water_ml INTEGER NOT NULL DEFAULT 0` for per-day hydration tracking
- **Migration v32**: `CREATE TABLE body_measurements` (id, date UNIQUE, waist/chest/hips/thigh/arm _cm REAL) for body measurement logging
- **database.ts**: new accessors `getWaterForDay`, `addWater`, `setWaterForDay`, `getWaterHistory`, `getHydrationGoal`, `setHydrationGoal`, `logBodyMeasurement` (upsert, partial-field update), `getBodyMeasurements`, `getLatestMeasurements`; exports `BodyMeasurement` type
- **analyticsHelpers.ts**: pure helpers `hydrationAverage`, `hydrationGoalAdherence`, `measurementDelta`, `latestMeasurementValue` with `HydrationDay` / `MeasurementPoint` / `MeasurementField` types
- **analyticsHelpers.test.ts**: 19 new unit tests covering all four helpers (268 total, all passing)
- **DashboardScreen**: hydration card (sky accent, ProgressBar vs goal, +250/+500/−250 quick-add) + body measurements section (clay accent, latest values as pills, MeasurementsModal bottom sheet for logging)
- **SettingsScreen**: "Hydration goal" card with ±250 ml stepper (250–6000 ml range, persisted in app_state KV)
- **AnalyticsDashboardScreen**: `HydrationSummaryCard` (7-day avg, adherence %, goal; per-day bar chart) + `MeasurementsTrendCard` (latest value + first-to-last delta per field)
- All styles use Verdure tokens exclusively; no new npm dependencies

## Test plan

- [ ] `npm run typecheck` — 0 errors
- [ ] `npm test` — 268 tests, 16 suites, all passing
- [ ] DashboardScreen: tap +250 ml, verify count increments and ProgressBar grows
- [ ] DashboardScreen: tap −250 ml at 0 ml, verify count stays at 0 (clamped)
- [ ] DashboardScreen: tap "Log" in measurements section, fill waist + arm, save — verify pills update
- [ ] SettingsScreen: adjust hydration goal, navigate away and back — verify value persists
- [ ] AnalyticsDashboardScreen: verify HydrationSummaryCard and MeasurementsTrendCard render without errors

Closes #283