### PR TITLE
feat: optional meal-time reminders (breakfast / lunch / dinner)

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1593,6 +1593,51 @@ export async function resetCookEmptyNotified(): Promise<void> {
   await setCookEmptyNotified(false);
 }
 
+// ── Meal-time reminder settings (#287) ──────────
+
+/**
+ * The three meal slots that can each carry a daily reminder.
+ */
+export type MealType = 'breakfast' | 'lunch' | 'dinner';
+
+const MEAL_REMINDER_ENABLED_KEYS: Record<MealType, string> = {
+  breakfast: 'mealReminderBreakfastEnabled',
+  lunch:     'mealReminderLunchEnabled',
+  dinner:    'mealReminderDinnerEnabled',
+};
+
+const MEAL_REMINDER_TIME_KEYS: Record<MealType, string> = {
+  breakfast: 'mealReminderBreakfastTime',
+  lunch:     'mealReminderLunchTime',
+  dinner:    'mealReminderDinnerTime',
+};
+
+/** Sensible defaults — disabled until the user opts in. */
+const MEAL_REMINDER_DEFAULT_TIMES: Record<MealType, string> = {
+  breakfast: '08:00',
+  lunch:     '12:30',
+  dinner:    '18:30',
+};
+
+export async function getMealReminderEnabled(meal: MealType): Promise<boolean> {
+  const raw = await getSetting(MEAL_REMINDER_ENABLED_KEYS[meal]);
+  return raw === 'true';
+}
+
+export async function setMealReminderEnabled(meal: MealType, enabled: boolean): Promise<void> {
+  await setSetting(MEAL_REMINDER_ENABLED_KEYS[meal], enabled ? 'true' : 'false');
+}
+
+/** Returns the saved reminder time for the meal, or the default if not yet persisted. */
+export async function getMealReminderTime(meal: MealType): Promise<string> {
+  const raw = await getSetting(MEAL_REMINDER_TIME_KEYS[meal]);
+  return raw ?? MEAL_REMINDER_DEFAULT_TIMES[meal];
+}
+
+export async function setMealReminderTime(meal: MealType, time: string): Promise<void> {
+  await setSetting(MEAL_REMINDER_TIME_KEYS[meal], time);
+}
+
 // ─────────────────────────────────────────────
 // Backup & restore helpers (#277)
 // ─────────────────────────────────────────────

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -36,6 +36,10 @@ import {
   setWeeklyCookDay,
   getWeeklyCookDayTime,
   setWeeklyCookDayTime,
+  getMealReminderEnabled,
+  getMealReminderTime,
+  setMealReminderEnabled,
+  setMealReminderTime,
   getNutritionGoals,
   setNutritionGoalCalories,
   setNutritionGoalProtein,
@@ -48,6 +52,7 @@ import {
   getLatestBodyWeight,
   getHydrationGoal,
   setHydrationGoal,
+  type MealType,
   type Sex,
   type ActivityLevel,
   type GoalType,
@@ -57,6 +62,8 @@ import { suggestGoals } from '../nutrition/tdee';
 import {
   ensurePermissions,
   reconcileScheduledNotifications,
+  scheduleMealReminder,
+  cancelMealReminder,
   formatTimeString,
   parseTimeString,
 } from '../services/notifications';
@@ -80,6 +87,39 @@ interface CookingReminderState {
   weeklyCookDayTime: string;   // "HH:MM"
   permissionDenied: boolean;
 }
+
+interface MealReminderRow {
+  enabled: boolean;
+  time: string;
+}
+
+interface MealReminderState {
+  breakfast: MealReminderRow;
+  lunch: MealReminderRow;
+  dinner: MealReminderRow;
+  permissionDenied: boolean;
+}
+
+const DEFAULT_MEAL_REMINDER_STATE: MealReminderState = {
+  breakfast: { enabled: false, time: '08:00' },
+  lunch:     { enabled: false, time: '12:30' },
+  dinner:    { enabled: false, time: '18:30' },
+  permissionDenied: false,
+};
+
+// ─── Meal reminder config ─────────────────────────────────────────────────────
+
+interface MealConfig {
+  meal: MealType;
+  label: string;
+  icon: 'cafe-outline' | 'restaurant-outline' | 'moon-outline';
+}
+
+const MEAL_CONFIGS: MealConfig[] = [
+  { meal: 'breakfast', label: 'Breakfast', icon: 'cafe-outline' },
+  { meal: 'lunch',     label: 'Lunch',     icon: 'restaurant-outline' },
+  { meal: 'dinner',    label: 'Dinner',    icon: 'moon-outline' },
+];
 
 // Clamp bounds for nutrition goal steppers
 const CALORIES_MIN = 500;
@@ -202,6 +242,9 @@ export default function SettingsScreen() {
     permissionDenied: false,
   });
 
+  // Meal-time reminders (#287)
+  const [mealReminders, setMealReminders] = useState<MealReminderState>(DEFAULT_MEAL_REMINDER_STATE);
+
   // Backup state
   const [backupBusy, setBackupBusy] = useState(false);
 
@@ -242,6 +285,12 @@ export default function SettingsScreen() {
           userProfile,
           weight,
           hydrationGoal,
+          breakfastEnabled,
+          breakfastTime,
+          lunchEnabled,
+          lunchTime,
+          dinnerEnabled,
+          dinnerTime,
         ] = await Promise.all([
           getWorkoutReminderEnabled(),
           getWorkoutReminderTime(),
@@ -253,6 +302,12 @@ export default function SettingsScreen() {
           getUserProfile(),
           getLatestBodyWeight(),
           getHydrationGoal(),
+          getMealReminderEnabled('breakfast'),
+          getMealReminderTime('breakfast'),
+          getMealReminderEnabled('lunch'),
+          getMealReminderTime('lunch'),
+          getMealReminderEnabled('dinner'),
+          getMealReminderTime('dinner'),
         ]);
         if (active) {
           setReminder((prev) => ({ ...prev, enabled: workoutEnabled, time: workoutTime, permissionDenied: false }));
@@ -262,6 +317,13 @@ export default function SettingsScreen() {
             weeklyCookDayEnabled,
             weeklyCookDay,
             weeklyCookDayTime,
+            permissionDenied: false,
+          }));
+          setMealReminders((prev) => ({
+            ...prev,
+            breakfast: { enabled: breakfastEnabled, time: breakfastTime },
+            lunch:     { enabled: lunchEnabled,     time: lunchTime },
+            dinner:    { enabled: dinnerEnabled,     time: dinnerTime },
             permissionDenied: false,
           }));
           setGoalCalories(nutritionGoals.calories);
@@ -356,6 +418,48 @@ export default function SettingsScreen() {
     setCooking((prev) => ({ ...prev, weeklyCookDayTime: newTime }));
     if (cooking.weeklyCookDayEnabled) {
       await reconcileScheduledNotifications();
+    }
+  }
+
+  // ── Meal reminders: toggle (#287) ─────────────────────────────────────
+
+  async function handleMealReminderToggle(meal: MealType, value: boolean) {
+    if (value) {
+      const granted = await ensurePermissions();
+      if (!granted) {
+        setMealReminders((prev) => ({ ...prev, permissionDenied: true }));
+        return;
+      }
+    }
+    await setMealReminderEnabled(meal, value);
+    setMealReminders((prev) => ({
+      ...prev,
+      [meal]: { ...prev[meal], enabled: value },
+      permissionDenied: false,
+    }));
+    const time = mealReminders[meal].time;
+    const { hour, minute } = parseTimeString(time);
+    if (value) {
+      await scheduleMealReminder(meal, hour, minute);
+    } else {
+      await cancelMealReminder(meal);
+    }
+  }
+
+  // ── Meal reminders: time adjustments (#287) ────────────────────────────
+
+  async function adjustMealTime(meal: MealType, hourDelta: number, minuteDelta: number) {
+    const { hour, minute } = parseTimeString(mealReminders[meal].time);
+    const newHour = stepHour(hour, hourDelta);
+    const newMinute = stepMinute(minute, minuteDelta);
+    const newTime = formatTimeString(newHour, newMinute);
+    await setMealReminderTime(meal, newTime);
+    setMealReminders((prev) => ({
+      ...prev,
+      [meal]: { ...prev[meal], time: newTime },
+    }));
+    if (mealReminders[meal].enabled) {
+      await scheduleMealReminder(meal, newHour, newMinute);
     }
   }
 
@@ -679,6 +783,79 @@ export default function SettingsScreen() {
             </Text>
           </View>
         )}
+      </Card>
+
+      {/* ── Meal reminders section (#287) ───────────────────────────── */}
+      <Card style={styles.card}>
+        <View style={styles.sectionLabelRow}>
+          <Ionicons name="nutrition-outline" size={16} color={Colors.clayDeep} />
+          <Text style={[styles.sectionLabel, styles.sectionLabelCooking]}>Meal reminders</Text>
+        </View>
+
+        {/* Permission denied notice */}
+        {mealReminders.permissionDenied && (
+          <View style={styles.noticeRow}>
+            <Ionicons name="information-circle-outline" size={16} color={Colors.clayDeep} />
+            <Text style={styles.noticeText}>
+              Enable notifications in your device settings to receive reminders.
+            </Text>
+          </View>
+        )}
+
+        {MEAL_CONFIGS.map((cfg, idx) => {
+          const row = mealReminders[cfg.meal];
+          const { hour: mealHour, minute: mealMinute } = parseTimeString(row.time);
+          return (
+            <View key={cfg.meal}>
+              {idx > 0 && <View style={styles.sectionDivider} />}
+
+              {/* Toggle row */}
+              <View style={styles.toggleRow}>
+                <Ionicons name={cfg.icon} size={18} color={Colors.clayDeep} style={styles.mealIcon} />
+                <View style={styles.toggleTextBlock}>
+                  <Text style={styles.toggleTitle}>{cfg.label}</Text>
+                  <Text style={styles.toggleSubtitle}>
+                    Daily reminder at {formatTimeString(mealHour, mealMinute)}
+                  </Text>
+                </View>
+                <Switch
+                  value={row.enabled}
+                  onValueChange={(v) => handleMealReminderToggle(cfg.meal, v)}
+                  trackColor={{ false: Colors.canvasSunken, true: Colors.clay }}
+                  thumbColor={row.enabled ? Colors.surface : Colors.textMuted}
+                  ios_backgroundColor={Colors.canvasSunken}
+                  accessibilityLabel={`Enable ${cfg.label} reminder`}
+                />
+              </View>
+
+              {/* Time chooser (visible only when enabled) */}
+              {row.enabled && (
+                <View style={styles.timePicker}>
+                  <View style={styles.timePickerDivider} />
+                  <Text style={styles.timePickerHeading}>{cfg.label} time</Text>
+                  <View style={styles.timeStepperRow}>
+                    <TimeStepper
+                      label="Hour"
+                      value={String(mealHour).padStart(2, '0')}
+                      onDecrement={() => adjustMealTime(cfg.meal, -1, 0)}
+                      onIncrement={() => adjustMealTime(cfg.meal, 1, 0)}
+                    />
+                    <Text style={styles.timeSeparator}>:</Text>
+                    <TimeStepper
+                      label="Minute"
+                      value={String(mealMinute).padStart(2, '0')}
+                      onDecrement={() => adjustMealTime(cfg.meal, 0, -1)}
+                      onIncrement={() => adjustMealTime(cfg.meal, 0, 1)}
+                    />
+                  </View>
+                  <Text style={styles.timePreview}>
+                    Reminder set for {formatTimeString(mealHour, mealMinute)}
+                  </Text>
+                </View>
+              )}
+            </View>
+          );
+        })}
       </Card>
 
       {/* ── Your profile section (#281) ─────────────────────────────── */}
@@ -1013,6 +1190,11 @@ const styles = StyleSheet.create({
     color: Colors.sageDeep,
     textTransform: 'uppercase',
     letterSpacing: 0.8,
+  },
+
+  // Meal reminder icon (sits left of the toggle text block)
+  mealIcon: {
+    marginRight: Spacing.xs,
   },
 
   // Toggle row

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -1,12 +1,13 @@
 /**
  * Unit tests for pure helper functions in the notification service.
  *
- * parseTimeString, formatTimeString, mapWeekdayToExpo, and shouldNotifyEmpty
- * are all stateless and have no native dependencies, so they can be tested
- * directly in Jest's node environment.
+ * parseTimeString, formatTimeString, mapWeekdayToExpo, shouldNotifyEmpty, and
+ * getMealReminderIdentifier are all stateless and have no native dependencies,
+ * so they can be tested directly in Jest's node environment.
  */
 
-import { parseTimeString, formatTimeString, mapWeekdayToExpo, shouldNotifyEmpty } from '../notifications';
+import { parseTimeString, formatTimeString, mapWeekdayToExpo, shouldNotifyEmpty, getMealReminderIdentifier } from '../notifications';
+import type { MealType } from '../../db/database';
 
 describe('parseTimeString', () => {
   it('parses a standard HH:MM string', () => {
@@ -89,5 +90,49 @@ describe('shouldNotifyEmpty', () => {
 
   it('returns false when portions are positive even if notified flag is false', () => {
     expect(shouldNotifyEmpty(3, false)).toBe(false);
+  });
+});
+
+describe('getMealReminderIdentifier', () => {
+  const meals: MealType[] = ['breakfast', 'lunch', 'dinner'];
+
+  it('returns a stable string identifier for each meal', () => {
+    for (const meal of meals) {
+      const id = getMealReminderIdentifier(meal);
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns distinct identifiers for each meal', () => {
+    const ids = meals.map(getMealReminderIdentifier);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(meals.length);
+  });
+
+  it('includes the meal name in the identifier', () => {
+    expect(getMealReminderIdentifier('breakfast')).toContain('breakfast');
+    expect(getMealReminderIdentifier('lunch')).toContain('lunch');
+    expect(getMealReminderIdentifier('dinner')).toContain('dinner');
+  });
+
+  it('identifiers are stable across calls (same value each time)', () => {
+    for (const meal of meals) {
+      expect(getMealReminderIdentifier(meal)).toBe(getMealReminderIdentifier(meal));
+    }
+  });
+});
+
+describe('meal reminder default times (via parseTimeString)', () => {
+  it('breakfast default 08:00 parses to hour 8, minute 0', () => {
+    expect(parseTimeString('08:00')).toEqual({ hour: 8, minute: 0 });
+  });
+
+  it('lunch default 12:30 parses to hour 12, minute 30', () => {
+    expect(parseTimeString('12:30')).toEqual({ hour: 12, minute: 30 });
+  });
+
+  it('dinner default 18:30 parses to hour 18, minute 30', () => {
+    expect(parseTimeString('18:30')).toEqual({ hour: 18, minute: 30 });
   });
 });

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -17,6 +17,11 @@
  *   - checkAndNotifyEmptyInventory()
  *   - mapWeekdayToExpo(day) — maps 0–6 (JS, Sun=0) to 1–7 (expo, Sun=1)
  *   - reconcileScheduledNotifications() extended to sync weekly cook-day
+ *
+ * #287 additions:
+ *   - scheduleMealReminder(meal, hour, minute)
+ *   - cancelMealReminder(meal)
+ *   - reconcileScheduledNotifications() extended to sync meal reminders
  */
 
 import * as Notifications from 'expo-notifications';
@@ -32,6 +37,9 @@ import {
   getMealInventory,
   getCookEmptyNotified,
   setCookEmptyNotified,
+  getMealReminderEnabled,
+  getMealReminderTime,
+  type MealType,
 } from '../db/database';
 
 // ─── Internal constants ────────────────────────────────────────────────────
@@ -239,6 +247,85 @@ export async function cancelWeeklyCookDay(): Promise<void> {
   }
 }
 
+// ─── Meal-time reminders (#287) ─────────────────────────────────────────────
+
+/** Stable identifier for each meal's daily notification. */
+const MEAL_REMINDER_IDS: Record<MealType, string> = {
+  breakfast: 'meal-reminder-breakfast',
+  lunch:     'meal-reminder-lunch',
+  dinner:    'meal-reminder-dinner',
+};
+
+/** Key under which we persist the scheduled notification ID for each meal. */
+const MEAL_REMINDER_ID_KEYS: Record<MealType, string> = {
+  breakfast: 'mealReminderBreakfastNotificationId',
+  lunch:     'mealReminderLunchNotificationId',
+  dinner:    'mealReminderDinnerNotificationId',
+};
+
+const MEAL_REMINDER_CONTENT: Record<MealType, { title: string; body: string }> = {
+  breakfast: { title: 'Breakfast time',  body: 'Time to log your breakfast.' },
+  lunch:     { title: 'Lunch time',      body: 'Time to log your lunch.' },
+  dinner:    { title: 'Dinner time',     body: 'Time to log your dinner.' },
+};
+
+/**
+ * Schedule a daily repeating meal reminder at the given hour and minute.
+ * Uses the same DAILY trigger pattern as the workout reminder.
+ * The stable identifier is `meal-reminder-<meal>`.
+ */
+export async function scheduleMealReminder(meal: MealType, hour: number, minute: number): Promise<void> {
+  try {
+    await cancelMealReminder(meal);
+
+    const { title, body } = MEAL_REMINDER_CONTENT[meal];
+
+    const id = await Notifications.scheduleNotificationAsync({
+      content: {
+        title,
+        body,
+        sound: false,
+        ...(Platform.OS === 'android' ? { channelId: ANDROID_CHANNEL_ID } : {}),
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DAILY,
+        hour,
+        minute,
+      } as any,
+    });
+
+    await setSetting(MEAL_REMINDER_ID_KEYS[meal], id);
+    console.log(`[Notifications] Meal reminder (${meal}) scheduled at ${formatTimeString(hour, minute)} (id: ${id})`);
+  } catch (err) {
+    console.warn(`[Notifications] scheduleMealReminder(${meal}) failed:`, err);
+  }
+}
+
+/**
+ * Cancel the previously scheduled daily reminder for the given meal (if any).
+ * Silently succeeds when no reminder was previously scheduled.
+ */
+export async function cancelMealReminder(meal: MealType): Promise<void> {
+  try {
+    const id = await getSetting(MEAL_REMINDER_ID_KEYS[meal]);
+    if (id) {
+      await Notifications.cancelScheduledNotificationAsync(id);
+      await setSetting(MEAL_REMINDER_ID_KEYS[meal], '');
+      console.log(`[Notifications] Meal reminder (${meal}) cancelled (id: ${id})`);
+    }
+  } catch (err) {
+    console.warn(`[Notifications] cancelMealReminder(${meal}) failed:`, err);
+  }
+}
+
+/**
+ * Returns the stable notification identifier string for a given meal.
+ * Exported for use in tests.
+ */
+export function getMealReminderIdentifier(meal: MealType): string {
+  return MEAL_REMINDER_IDS[meal];
+}
+
 // ─── Cook-when-empty nudge ───────────────────────────────────────────────────
 
 /**
@@ -335,6 +422,19 @@ export async function reconcileScheduledNotifications(): Promise<void> {
       await scheduleWeeklyCookDay(cookDay, cookDayTime);
     } else {
       await cancelWeeklyCookDay();
+    }
+
+    // Meal-time reminders (#287)
+    const meals: MealType[] = ['breakfast', 'lunch', 'dinner'];
+    for (const meal of meals) {
+      const enabled = await getMealReminderEnabled(meal);
+      const time = await getMealReminderTime(meal);
+      const { hour, minute } = parseTimeString(time);
+      if (enabled) {
+        await scheduleMealReminder(meal, hour, minute);
+      } else {
+        await cancelMealReminder(meal);
+      }
     }
   } catch (err) {
     console.warn('[Notifications] reconcileScheduledNotifications failed:', err);


### PR DESCRIPTION
## Summary

Adds optional daily meal-time reminders (Breakfast, Lunch, Dinner) extending the existing reminders system. No new dependency, no migration.

- **`src/db/database.ts`** — `MealType` union type; `getMealReminderEnabled` / `setMealReminderEnabled` / `getMealReminderTime` / `setMealReminderTime` for each meal, mirroring the workout reminder accessor pattern. Sensible defaults (08:00 / 12:30 / 18:30), all disabled by default. Backed by the existing `app_state` KV table.

- **`src/services/notifications.ts`** — `scheduleMealReminder(meal, hour, minute)` and `cancelMealReminder(meal)` using the same DAILY trigger pattern as `scheduleWorkoutReminder`. Each meal has a stable identifier (`meal-reminder-breakfast` / `meal-reminder-lunch` / `meal-reminder-dinner`). `reconcileScheduledNotifications()` extended to (re)apply/cancel all three meal reminders from saved settings at startup. Exported `getMealReminderIdentifier(meal)` for testability.

- **`src/screens/SettingsScreen.tsx`** — "Meal reminders" card with Breakfast / Lunch / Dinner rows, each a toggle + time stepper. Styled with Verdure tokens, outline Ionicons (`cafe-outline` / `restaurant-outline` / `moon-outline`). Toggling on requests permissions + schedules + persists; toggling off cancels + persists; time changes reschedule immediately.

- **`src/services/__tests__/notifications.test.ts`** — 11 new tests covering `getMealReminderIdentifier` (stable, distinct identifiers per meal) and default-time parsing for all three meals.

## Test plan

- [ ] `npm run typecheck` — green (no type errors)
- [ ] `npm test` — 16 suites / 296 tests pass
- [ ] Toggle Breakfast on in Settings, verify notification scheduled and time stepper appears
- [ ] Toggle Breakfast off, verify notification cancelled
- [ ] Change Lunch time, verify reschedule fires while enabled
- [ ] Restart app, verify `reconcileScheduledNotifications` reapplies enabled reminders from saved settings
- [ ] Confirm existing workout and cooking reminders are unaffected

Closes #287