### PR TITLE
style(theme): fix low-contrast foreground tokens for WCAG AA (#294)

### DIFF
--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -27,7 +27,7 @@ export const Colors = {
   // Text
   textPrimary: '#2C352E',     // deep pine
   textSecondary: '#5E665E',
-  textMuted: '#98A096',
+  textMuted: '#696E67',       // darkened from #98A096 for WCAG AA: ≥4.5:1 on surface & canvas (#294)
 
   // Completion badges
   badgeComplete: '#7C9A85',
@@ -40,7 +40,7 @@ export const Colors = {
   sageDeep: '#4E6B58',
   sageTint: '#E6ECE2',
   clay: '#C98A6B',
-  clayDeep: '#9A5E42',
+  clayDeep: '#945A3F',        // darkened from #9A5E42 for WCAG AA: ≥4.5:1 on clayTint (#294)
   clayTint: '#F3E6DB',
   sky: '#8FAABF',
   skyDeep: '#516675',


### PR DESCRIPTION
## Summary

Darkens the two foreground color tokens flagged by the #290 accessibility pass so that all foreground/background pairings in the Verdure theme meet WCAG AA (>=4.5:1 contrast ratio for normal text).

### Before / After

| Token | Before | After | Pair | Before ratio | After ratio |
|---|---|---|---|---|---|
| `textMuted` | `#98A096` | `#696E67` | on `surface` (#FBF9F4) | 2.56:1 fail | 4.96:1 pass |
| `textMuted` | `#98A096` | `#696E67` | on `canvas` (#F3EFE7) | 2.35:1 fail | 4.55:1 pass |
| `clayDeep` | `#9A5E42` | `#945A3F` | on `clayTint` (#F3E6DB) | 4.23:1 fail | 4.52:1 pass |

Reference: `sageDeep` (#4E6B58) on `sageTint` (#E6ECE2) was already passing at 4.89:1 and is unchanged.

### Approach

- Uniform RGB channel scaling (all channels multiplied by the same factor) to preserve hue family and Verdure character while reaching the minimum luminance required for AA.
- `textMuted` scaled to 0.690x — the binding constraint is the canvas background (lighter than surface produces the harder test).
- `clayDeep` scaled to 0.960x — a very small change, just enough to clear 4.5:1 on the clay tint.
- Background tokens (`surface`, `canvas`, `clayTint`) are not touched.

### Files changed

Only `src/theme/tokens.ts` — values-only change, no component code, no migrations, no new dependencies.

### Verification

- `npm run typecheck` — exit 0
- `npm test` — 296 tests, 16 suites, all green

Closes #294