### PR TITLE
feat(backup-loop): auto-snapshot before restore + periodic backup reminder

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -2179,3 +2179,53 @@ export async function deleteWorkoutSet(id: number): Promise<void> {
   const db = getDatabase();
   await db.runAsync('DELETE FROM workout_set_log WHERE id = ?', [id]);
 }
+
+// ── Backup reminder settings (#293) ──────────────────────────────────────────
+//
+// Stored as KV pairs in app_state — no schema migration required.
+// Disabled by default; the user opts in from the "Data & backup" section of
+// SettingsScreen.
+
+const SETTING_BACKUP_REMINDER_ENABLED = 'backupReminderEnabled';
+const SETTING_BACKUP_REMINDER_DAY     = 'backupReminderDay';
+const SETTING_BACKUP_REMINDER_TIME    = 'backupReminderTime';
+
+const DEFAULT_BACKUP_REMINDER_DAY  = 0;       // Sunday
+const DEFAULT_BACKUP_REMINDER_TIME = '18:00'; // 6 pm
+
+/** Returns true when the periodic backup reminder is enabled. Default: false. */
+export async function getBackupReminderEnabled(): Promise<boolean> {
+  const raw = await getSetting(SETTING_BACKUP_REMINDER_ENABLED);
+  return raw === 'true';
+}
+
+/** Persist whether the periodic backup reminder is enabled. */
+export async function setBackupReminderEnabled(enabled: boolean): Promise<void> {
+  await setSetting(SETTING_BACKUP_REMINDER_ENABLED, enabled ? 'true' : 'false');
+}
+
+/** Returns the saved weekday (0–6, 0 = Sunday) for the backup reminder. */
+export async function getBackupReminderDay(): Promise<number> {
+  const raw = await getSetting(SETTING_BACKUP_REMINDER_DAY);
+  if (raw === null) return DEFAULT_BACKUP_REMINDER_DAY;
+  const parsed = parseInt(raw, 10);
+  return isNaN(parsed) || parsed < 0 || parsed > 6
+    ? DEFAULT_BACKUP_REMINDER_DAY
+    : parsed;
+}
+
+/** Persist the weekday (0–6) for the backup reminder. */
+export async function setBackupReminderDay(day: number): Promise<void> {
+  await setSetting(SETTING_BACKUP_REMINDER_DAY, String(day));
+}
+
+/** Returns the saved time ("HH:MM") for the backup reminder. Default: "18:00". */
+export async function getBackupReminderTime(): Promise<string> {
+  const raw = await getSetting(SETTING_BACKUP_REMINDER_TIME);
+  return raw ?? DEFAULT_BACKUP_REMINDER_TIME;
+}
+
+/** Persist the time ("HH:MM") for the backup reminder. */
+export async function setBackupReminderTime(time: string): Promise<void> {
+  await setSetting(SETTING_BACKUP_REMINDER_TIME, time);
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -40,6 +40,12 @@ import {
   getMealReminderTime,
   setMealReminderEnabled,
   setMealReminderTime,
+  getBackupReminderEnabled,
+  setBackupReminderEnabled,
+  getBackupReminderDay,
+  setBackupReminderDay,
+  getBackupReminderTime,
+  setBackupReminderTime,
   getNutritionGoals,
   setNutritionGoalCalories,
   setNutritionGoalProtein,
@@ -64,10 +70,12 @@ import {
   reconcileScheduledNotifications,
   scheduleMealReminder,
   cancelMealReminder,
+  scheduleBackupReminder,
+  cancelBackupReminder,
   formatTimeString,
   parseTimeString,
 } from '../services/notifications';
-import { exportBackup, importBackup } from '../services/backup';
+import { exportBackup, importBackup, shareFile } from '../services/backup';
 import Card from '../components/Card';
 import ScreenHeader from '../components/ScreenHeader';
 import { Colors, Spacing, Typography, Radius } from '../theme/tokens';
@@ -104,6 +112,22 @@ const DEFAULT_MEAL_REMINDER_STATE: MealReminderState = {
   breakfast: { enabled: false, time: '08:00' },
   lunch:     { enabled: false, time: '12:30' },
   dinner:    { enabled: false, time: '18:30' },
+  permissionDenied: false,
+};
+
+// ─── Backup reminder state (#293) ─────────────────────────────────────────────
+
+interface BackupReminderState {
+  enabled: boolean;
+  day: number;    // 0–6 (0 = Sunday)
+  time: string;   // "HH:MM"
+  permissionDenied: boolean;
+}
+
+const DEFAULT_BACKUP_REMINDER_STATE: BackupReminderState = {
+  enabled: false,
+  day: 0,
+  time: '18:00',
   permissionDenied: false,
 };
 
@@ -245,6 +269,9 @@ export default function SettingsScreen() {
   // Meal-time reminders (#287)
   const [mealReminders, setMealReminders] = useState<MealReminderState>(DEFAULT_MEAL_REMINDER_STATE);
 
+  // Backup reminder (#293)
+  const [backupReminder, setBackupReminder] = useState<BackupReminderState>(DEFAULT_BACKUP_REMINDER_STATE);
+
   // Backup state
   const [backupBusy, setBackupBusy] = useState(false);
 
@@ -291,6 +318,9 @@ export default function SettingsScreen() {
           lunchTime,
           dinnerEnabled,
           dinnerTime,
+          backupEnabled,
+          backupDay,
+          backupTime,
         ] = await Promise.all([
           getWorkoutReminderEnabled(),
           getWorkoutReminderTime(),
@@ -308,6 +338,9 @@ export default function SettingsScreen() {
           getMealReminderTime('lunch'),
           getMealReminderEnabled('dinner'),
           getMealReminderTime('dinner'),
+          getBackupReminderEnabled(),
+          getBackupReminderDay(),
+          getBackupReminderTime(),
         ]);
         if (active) {
           setReminder((prev) => ({ ...prev, enabled: workoutEnabled, time: workoutTime, permissionDenied: false }));
@@ -324,6 +357,13 @@ export default function SettingsScreen() {
             breakfast: { enabled: breakfastEnabled, time: breakfastTime },
             lunch:     { enabled: lunchEnabled,     time: lunchTime },
             dinner:    { enabled: dinnerEnabled,     time: dinnerTime },
+            permissionDenied: false,
+          }));
+          setBackupReminder((prev) => ({
+            ...prev,
+            enabled: backupEnabled,
+            day: backupDay,
+            time: backupTime,
             permissionDenied: false,
           }));
           setGoalCalories(nutritionGoals.calories);
@@ -571,7 +611,7 @@ export default function SettingsScreen() {
     if (backupBusy) return;
     Alert.alert(
       'Restore from backup',
-      'This will replace ALL current data with the contents of the backup file. This cannot be undone. Continue?',
+      'This will replace ALL current data with the contents of the backup file. A safety copy of your current data will be saved first. Continue?',
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -580,15 +620,43 @@ export default function SettingsScreen() {
           onPress: async () => {
             setBackupBusy(true);
             try {
-              const result = await importBackup();
+              const result = await importBackup({
+                onSnapshotFailed: async (errorMessage) => {
+                  return new Promise<boolean>((resolve) => {
+                    Alert.alert(
+                      'Safety copy failed',
+                      `Could not save a safety copy of your current data (${errorMessage}). Proceeding may make the restore unrecoverable. Continue anyway?`,
+                      [
+                        { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+                        { text: 'Continue anyway', style: 'destructive', onPress: () => resolve(true) },
+                      ]
+                    );
+                  });
+                },
+              });
               if (result === null) {
                 // User cancelled the picker — no action needed
                 return;
               }
-              Alert.alert(
-                'Restore complete',
-                `Restored ${result.tablesRestored} tables and ${result.rowsRestored} rows. Revisit each screen to see the updated data.`
-              );
+              // Offer to share the safety snapshot if one was written
+              if (result.safetySnapshotUri) {
+                Alert.alert(
+                  'Restore complete',
+                  `Restored ${result.tablesRestored} tables and ${result.rowsRestored} rows.\n\nA safety copy of your previous data was saved. Would you like to share it?`,
+                  [
+                    { text: 'Dismiss', style: 'cancel' },
+                    {
+                      text: 'Share safety copy',
+                      onPress: () => shareFile(result.safetySnapshotUri),
+                    },
+                  ]
+                );
+              } else {
+                Alert.alert(
+                  'Restore complete',
+                  `Restored ${result.tablesRestored} tables and ${result.rowsRestored} rows. Revisit each screen to see the updated data.`
+                );
+              }
             } catch (err) {
               const message =
                 err instanceof Error ? err.message : 'Something went wrong.';
@@ -602,8 +670,48 @@ export default function SettingsScreen() {
     );
   }
 
+  // ── Backup reminder: toggle (#293) ───────────────────────────────────────
+
+  async function handleBackupReminderToggle(value: boolean) {
+    if (value) {
+      const granted = await ensurePermissions();
+      if (!granted) {
+        setBackupReminder((prev) => ({ ...prev, permissionDenied: true }));
+        return;
+      }
+    }
+    await setBackupReminderEnabled(value);
+    setBackupReminder((prev) => ({ ...prev, enabled: value, permissionDenied: false }));
+    await reconcileScheduledNotifications();
+  }
+
+  // ── Backup reminder: weekday chip ─────────────────────────────────────────
+
+  async function handleBackupReminderDaySelect(day: number) {
+    await setBackupReminderDay(day);
+    setBackupReminder((prev) => ({ ...prev, day }));
+    if (backupReminder.enabled) {
+      await reconcileScheduledNotifications();
+    }
+  }
+
+  // ── Backup reminder: time adjustments ─────────────────────────────────────
+
+  async function adjustBackupReminderTime(hourDelta: number, minuteDelta: number) {
+    const { hour, minute } = parseTimeString(backupReminder.time);
+    const newHour = stepHour(hour, hourDelta);
+    const newMinute = stepMinute(minute, minuteDelta);
+    const newTime = formatTimeString(newHour, newMinute);
+    await setBackupReminderTime(newTime);
+    setBackupReminder((prev) => ({ ...prev, time: newTime }));
+    if (backupReminder.enabled) {
+      await scheduleBackupReminder(backupReminder.day, newTime);
+    }
+  }
+
   const { hour: workoutHour, minute: workoutMinute } = parseTimeString(reminder.time);
   const { hour: cookHour, minute: cookMinute } = parseTimeString(cooking.weeklyCookDayTime);
+  const { hour: backupHour, minute: backupMinute } = parseTimeString(backupReminder.time);
 
   return (
     <ScrollView
@@ -1154,6 +1262,92 @@ export default function SettingsScreen() {
           </View>
           <Ionicons name="chevron-forward-outline" size={16} color={Colors.textMuted} />
         </TouchableOpacity>
+
+        <View style={styles.sectionDivider} />
+
+        {/* ── Backup reminder (#293) ──────────────────────────── */}
+        <View style={styles.sectionLabelRow}>
+          <Ionicons name="shield-checkmark-outline" size={16} color={Colors.skyDeep} />
+          <Text style={[styles.sectionLabel, styles.sectionLabelBackup]}>Backup reminder</Text>
+        </View>
+
+        {/* Permission denied notice */}
+        {backupReminder.permissionDenied && (
+          <View style={styles.noticeRow}>
+            <Ionicons name="information-circle-outline" size={16} color={Colors.clayDeep} />
+            <Text style={styles.noticeText}>
+              Enable notifications in your device settings to receive reminders.
+            </Text>
+          </View>
+        )}
+
+        {/* Toggle row */}
+        <View style={styles.toggleRow}>
+          <View style={styles.toggleTextBlock}>
+            <Text style={styles.toggleTitle}>Weekly backup reminder</Text>
+            <Text style={styles.toggleSubtitle}>
+              A nudge to save a backup on your chosen day
+            </Text>
+          </View>
+          <Switch
+            value={backupReminder.enabled}
+            onValueChange={handleBackupReminderToggle}
+            trackColor={{ false: Colors.canvasSunken, true: Colors.sky }}
+            thumbColor={backupReminder.enabled ? Colors.surface : Colors.textMuted}
+            ios_backgroundColor={Colors.canvasSunken}
+            accessibilityLabel="Enable weekly backup reminder"
+          />
+        </View>
+
+        {/* Weekday + time chooser (visible only when enabled) */}
+        {backupReminder.enabled && (
+          <View style={styles.timePicker}>
+            <View style={styles.timePickerDivider} />
+
+            {/* Weekday chip selector */}
+            <Text style={styles.timePickerHeading}>Reminder day</Text>
+            <View style={styles.weekdayRow}>
+              {DAY_LABELS.map((label, idx) => {
+                const selected = backupReminder.day === idx;
+                return (
+                  <TouchableOpacity
+                    key={label}
+                    style={[styles.weekdayChip, selected && styles.weekdayChipBackupSelected]}
+                    onPress={() => handleBackupReminderDaySelect(idx)}
+                    accessibilityLabel={`Select ${label}`}
+                    accessibilityRole="button"
+                    activeOpacity={0.7}
+                  >
+                    <Text style={[styles.weekdayChipLabel, selected && styles.weekdayChipLabelBackupSelected]}>
+                      {label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+
+            {/* Time stepper */}
+            <Text style={[styles.timePickerHeading, styles.timePickerHeadingSpaced]}>Reminder time</Text>
+            <View style={styles.timeStepperRow}>
+              <TimeStepper
+                label="Hour"
+                value={String(backupHour).padStart(2, '0')}
+                onDecrement={() => adjustBackupReminderTime(-1, 0)}
+                onIncrement={() => adjustBackupReminderTime(1, 0)}
+              />
+              <Text style={styles.timeSeparator}>:</Text>
+              <TimeStepper
+                label="Minute"
+                value={String(backupMinute).padStart(2, '0')}
+                onDecrement={() => adjustBackupReminderTime(0, -1)}
+                onIncrement={() => adjustBackupReminderTime(0, 1)}
+              />
+            </View>
+            <Text style={styles.timePreview}>
+              Reminder every {DAY_LABELS[backupReminder.day]} at {formatTimeString(backupHour, backupMinute)}
+            </Text>
+          </View>
+        )}
       </Card>
     </ScrollView>
   );
@@ -1310,6 +1504,9 @@ const styles = StyleSheet.create({
   weekdayChipSelected: {
     backgroundColor: Colors.clayTint,
   },
+  weekdayChipBackupSelected: {
+    backgroundColor: Colors.skyTint,
+  },
   weekdayChipLabel: {
     fontFamily: Typography.label,
     fontSize: Typography.sizes.xs,
@@ -1319,6 +1516,9 @@ const styles = StyleSheet.create({
   },
   weekdayChipLabelSelected: {
     color: Colors.clayDeep,
+  },
+  weekdayChipLabelBackupSelected: {
+    color: Colors.skyDeep,
   },
   timePickerHeadingSpaced: {
     marginTop: Spacing.md,

--- a/src/services/__tests__/backup.test.ts
+++ b/src/services/__tests__/backup.test.ts
@@ -8,11 +8,20 @@
  * Coverage:
  *   - buildInsertColumns: pure column/placeholder/values builder
  *   - validatePayload: format check, schema version compatibility gate
- *   - exportBackup / importBackup smoke: confirm the service exports the
- *     expected functions (consistent with the repo's existing test style)
+ *   - exportBackup / importBackup / buildBackupPayload / writeSafetySnapshot
+ *     smoke: confirm the service exports the expected functions (consistent
+ *     with the repo's existing test style)
  */
 
-import { buildInsertColumns, validatePayload, exportBackup, importBackup } from '../backup';
+import {
+  buildInsertColumns,
+  validatePayload,
+  exportBackup,
+  importBackup,
+  buildBackupPayload,
+  writeSafetySnapshot,
+  shareFile,
+} from '../backup';
 
 // ─── buildInsertColumns ───────────────────────────────────────────────────────
 
@@ -140,5 +149,17 @@ describe('backup service', () => {
 
   it('exports importBackup as a function', () => {
     expect(typeof importBackup).toBe('function');
+  });
+
+  it('exports buildBackupPayload as a function (#293)', () => {
+    expect(typeof buildBackupPayload).toBe('function');
+  });
+
+  it('exports writeSafetySnapshot as a function (#293)', () => {
+    expect(typeof writeSafetySnapshot).toBe('function');
+  });
+
+  it('exports shareFile as a function (#293)', () => {
+    expect(typeof shareFile).toBe('function');
   });
 });

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -1,12 +1,22 @@
 /**
  * Unit tests for pure helper functions in the notification service.
  *
- * parseTimeString, formatTimeString, mapWeekdayToExpo, shouldNotifyEmpty, and
- * getMealReminderIdentifier are all stateless and have no native dependencies,
- * so they can be tested directly in Jest's node environment.
+ * parseTimeString, formatTimeString, mapWeekdayToExpo, shouldNotifyEmpty,
+ * getMealReminderIdentifier, and getBackupReminderIdentifier are all stateless
+ * and have no native dependencies, so they can be tested directly in Jest's
+ * node environment.
  */
 
-import { parseTimeString, formatTimeString, mapWeekdayToExpo, shouldNotifyEmpty, getMealReminderIdentifier } from '../notifications';
+import {
+  parseTimeString,
+  formatTimeString,
+  mapWeekdayToExpo,
+  shouldNotifyEmpty,
+  getMealReminderIdentifier,
+  getBackupReminderIdentifier,
+  scheduleBackupReminder,
+  cancelBackupReminder,
+} from '../notifications';
 import type { MealType } from '../../db/database';
 
 describe('parseTimeString', () => {
@@ -134,5 +144,45 @@ describe('meal reminder default times (via parseTimeString)', () => {
 
   it('dinner default 18:30 parses to hour 18, minute 30', () => {
     expect(parseTimeString('18:30')).toEqual({ hour: 18, minute: 30 });
+  });
+});
+
+describe('getBackupReminderIdentifier', () => {
+  it('returns a non-empty string', () => {
+    const id = getBackupReminderIdentifier();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('contains "backup" in the identifier', () => {
+    expect(getBackupReminderIdentifier()).toContain('backup');
+  });
+
+  it('is stable across calls (same value each time)', () => {
+    expect(getBackupReminderIdentifier()).toBe(getBackupReminderIdentifier());
+  });
+
+  it('is distinct from all meal reminder identifiers', () => {
+    const meals: MealType[] = ['breakfast', 'lunch', 'dinner'];
+    const mealIds = meals.map(getMealReminderIdentifier);
+    const backupId = getBackupReminderIdentifier();
+    for (const mealId of mealIds) {
+      expect(backupId).not.toBe(mealId);
+    }
+  });
+
+  it('default backup reminder time parses correctly', () => {
+    // Default is 18:00 (Sunday evening)
+    expect(parseTimeString('18:00')).toEqual({ hour: 18, minute: 0 });
+  });
+});
+
+describe('backup reminder service (smoke)', () => {
+  it('exports scheduleBackupReminder as a function', () => {
+    expect(typeof scheduleBackupReminder).toBe('function');
+  });
+
+  it('exports cancelBackupReminder as a function', () => {
+    expect(typeof cancelBackupReminder).toBe('function');
   });
 });

--- a/src/services/backup.ts
+++ b/src/services/backup.ts
@@ -15,6 +15,8 @@
  *   - schema_version is NEVER included in the backup tables or overwritten
  *     on restore — that table is managed exclusively by runMigrations().
  *   - Restore is all-or-nothing via db.withTransactionAsync().
+ *   - Before any restore, a safety snapshot of the current data is written
+ *     to cacheDirectory so an accidental restore is always recoverable (#293).
  */
 
 import * as DocumentPicker from 'expo-document-picker';
@@ -46,6 +48,8 @@ export interface BackupPayload {
 export interface RestoreResult {
   tablesRestored: number;
   rowsRestored: number;
+  /** URI of the pre-restore safety snapshot written to cache. */
+  safetySnapshotUri: string;
 }
 
 // ─── Pure helpers (exported for unit tests) ──────────────────────────────────
@@ -130,6 +134,36 @@ function getAppVersion(): string {
 // Delegated to the canonical utility (issue #279).
 const isoDateString = localDateKey;
 
+// ─── Shared payload builder (exported for unit tests) ────────────────────────
+
+/**
+ * Dump all user tables from the database and assemble a BackupPayload object.
+ *
+ * This is the single source-of-truth for the serialization format — both
+ * exportBackup (user-initiated) and the pre-restore safety snapshot (#293)
+ * call this to avoid duplicating the dump/serialize logic.
+ *
+ * @returns A fully-populated BackupPayload ready for JSON serialization.
+ */
+export async function buildBackupPayload(): Promise<BackupPayload> {
+  const schemaVersion = await getCurrentSchemaVersion();
+  const tableNames = await listUserTables();
+  const tables: Record<string, Record<string, unknown>[]> = {};
+
+  for (const name of tableNames) {
+    tables[name] = await dumpTable(name);
+  }
+
+  return {
+    format: 'healthtracker-backup',
+    version: 1,
+    appVersion: getAppVersion(),
+    schemaVersion,
+    createdAt: new Date().toISOString(),
+    tables,
+  };
+}
+
 // ─── Export (backup) ─────────────────────────────────────────────────────────
 
 /**
@@ -147,23 +181,7 @@ export async function exportBackup(): Promise<string> {
     );
   }
 
-  // Dump all user tables
-  const schemaVersion = await getCurrentSchemaVersion();
-  const tableNames = await listUserTables();
-  const tables: Record<string, Record<string, unknown>[]> = {};
-
-  for (const name of tableNames) {
-    tables[name] = await dumpTable(name);
-  }
-
-  const payload: BackupPayload = {
-    format: 'healthtracker-backup',
-    version: 1,
-    appVersion: getAppVersion(),
-    schemaVersion,
-    createdAt: new Date().toISOString(),
-    tables,
-  };
+  const payload = await buildBackupPayload();
 
   const json = JSON.stringify(payload, null, 2);
   const fileName = `healthtracker-backup-${isoDateString()}.json`;
@@ -180,17 +198,68 @@ export async function exportBackup(): Promise<string> {
   return fileUri;
 }
 
+// ─── Safety snapshot (pre-restore) ───────────────────────────────────────────
+
+/**
+ * Produce a filename-safe ISO-ish timestamp for use in filenames.
+ * Replaces ':' with '-' and strips milliseconds so the name is readable on
+ * all platforms.
+ *
+ * Example: "2026-06-14T18-05-30"
+ */
+function safeTimestamp(): string {
+  return new Date().toISOString().replace(/:/g, '-').replace(/\.\d{3}Z$/, '');
+}
+
+/**
+ * Write a safety snapshot of the current DB state to cacheDirectory and
+ * return its URI.
+ *
+ * Called automatically by importBackup() before wiping any data so that a
+ * mistaken restore is always recoverable. The snapshot uses the same payload
+ * format as a regular export — it can be shared or imported as a normal
+ * backup file.
+ *
+ * @throws When the file write fails (caller decides whether to abort restore).
+ */
+export async function writeSafetySnapshot(): Promise<string> {
+  const payload = await buildBackupPayload();
+  const json = JSON.stringify(payload, null, 2);
+  const fileName = `healthtracker-pre-restore-${safeTimestamp()}.json`;
+  const fileUri = `${cacheDirectory ?? ''}${fileName}`;
+  await writeAsStringAsync(fileUri, json);
+  return fileUri;
+}
+
 // ─── Import (restore) ────────────────────────────────────────────────────────
 
 /**
  * Open the document picker, validate the chosen file as a HealthTracker
- * backup, then restore all tables transactionally.
+ * backup, write a safety snapshot of the current data, then restore all
+ * tables transactionally.
  *
- * @returns A RestoreResult summary, or null when the user cancelled.
+ * Safety snapshot behaviour (#293):
+ *   - Written to cacheDirectory before any data is modified.
+ *   - If the write fails the user is asked whether to continue; the restore
+ *     is aborted when they say no.
+ *   - The returned RestoreResult includes the snapshot URI so the caller can
+ *     offer to share it.
+ *
+ * @returns A RestoreResult summary (including safetySnapshotUri), or null
+ *          when the user cancelled.
  * @throws  When the file is invalid, the schema is incompatible, or the
  *          DB restore transaction fails.
  */
-export async function importBackup(): Promise<RestoreResult | null> {
+export async function importBackup(
+  options: {
+    /**
+     * Called when the safety-snapshot write fails. Receives the error message.
+     * Should return true to proceed with the restore anyway, false to abort.
+     * Defaults to always aborting (returns false) when omitted.
+     */
+    onSnapshotFailed?: (errorMessage: string) => Promise<boolean>;
+  } = {}
+): Promise<RestoreResult | null> {
   const result = await DocumentPicker.getDocumentAsync({
     type: 'application/json',
     copyToCacheDirectory: true,
@@ -214,5 +283,47 @@ export async function importBackup(): Promise<RestoreResult | null> {
   const currentSchemaVersion = await getCurrentSchemaVersion();
   const payload = validatePayload(parsed, currentSchemaVersion);
 
-  return restoreFromPayload(payload.tables);
+  // ── Safety snapshot (written BEFORE any data is wiped) ──────────────────
+  let safetySnapshotUri = '';
+  try {
+    safetySnapshotUri = await writeSafetySnapshot();
+    console.log(`[Backup] Safety snapshot written to: ${safetySnapshotUri}`);
+  } catch (snapshotErr) {
+    const msg =
+      snapshotErr instanceof Error
+        ? snapshotErr.message
+        : 'Unknown error writing safety snapshot.';
+
+    const proceed = options.onSnapshotFailed
+      ? await options.onSnapshotFailed(msg)
+      : false;
+
+    if (!proceed) {
+      throw new Error(
+        `Could not save a safety copy before restoring (${msg}). Restore aborted.`
+      );
+    }
+    // Caller chose to proceed despite failed snapshot — continue without URI.
+  }
+
+  const { tablesRestored, rowsRestored } = await restoreFromPayload(payload.tables);
+  return { tablesRestored, rowsRestored, safetySnapshotUri };
+}
+
+/**
+ * Share an existing file URI via the OS share sheet.
+ * Used to let the user save the safety snapshot after a restore completes.
+ *
+ * @param uri - A file:// URI returned by writeSafetySnapshot or exportBackup.
+ * @returns true when the share sheet was presented, false when sharing is unavailable.
+ */
+export async function shareFile(uri: string): Promise<boolean> {
+  const sharingAvailable = await Sharing.isAvailableAsync();
+  if (!sharingAvailable) return false;
+  await Sharing.shareAsync(uri, {
+    mimeType: 'application/json',
+    dialogTitle: 'Save your safety backup',
+    UTI: 'public.json',
+  });
+  return true;
 }

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -22,6 +22,12 @@
  *   - scheduleMealReminder(meal, hour, minute)
  *   - cancelMealReminder(meal)
  *   - reconcileScheduledNotifications() extended to sync meal reminders
+ *
+ * #293 additions:
+ *   - scheduleBackupReminder(day, time)
+ *   - cancelBackupReminder()
+ *   - getBackupReminderIdentifier()
+ *   - reconcileScheduledNotifications() extended to sync backup reminder
  */
 
 import * as Notifications from 'expo-notifications';
@@ -39,6 +45,9 @@ import {
   setCookEmptyNotified,
   getMealReminderEnabled,
   getMealReminderTime,
+  getBackupReminderEnabled,
+  getBackupReminderDay,
+  getBackupReminderTime,
   type MealType,
 } from '../db/database';
 
@@ -47,6 +56,11 @@ import {
 const ANDROID_CHANNEL_ID = 'reminders';
 const WORKOUT_REMINDER_ID_KEY = 'workoutReminderNotificationId';
 const WEEKLY_COOK_DAY_ID_KEY = 'weeklyCookDayNotificationId';
+
+/** Stable notification identifier for the backup reminder. */
+const BACKUP_REMINDER_IDENTIFIER = 'backup-reminder';
+/** app_state key for the OS-scheduled notification id. */
+const BACKUP_REMINDER_ID_KEY = 'backupReminderNotificationId';
 
 // ─── Foreground display handler ────────────────────────────────────────────
 
@@ -390,6 +404,71 @@ export async function checkAndNotifyEmptyInventory(): Promise<void> {
   }
 }
 
+// ─── Backup reminder (#293) ──────────────────────────────────────────────────
+
+/**
+ * Returns the stable notification identifier string for the backup reminder.
+ * Exported for use in tests.
+ */
+export function getBackupReminderIdentifier(): string {
+  return BACKUP_REMINDER_IDENTIFIER;
+}
+
+/**
+ * Schedule a weekly repeating backup reminder on the given weekday + time.
+ * Cancels any previously scheduled backup reminder first.
+ *
+ * Uses the same WEEKLY trigger pattern as scheduleWeeklyCookDay.
+ *
+ * @param day  0–6 (0 = Sunday)
+ * @param time "HH:MM"
+ */
+export async function scheduleBackupReminder(day: number, time: string): Promise<void> {
+  try {
+    await cancelBackupReminder();
+
+    const { hour, minute } = parseTimeString(time);
+    const weekday = mapWeekdayToExpo(day);
+
+    const id = await Notifications.scheduleNotificationAsync({
+      content: {
+        title: 'Back up your data',
+        body: "It's been a while — save a backup so you don't lose your history.",
+        sound: false,
+        ...(Platform.OS === 'android' ? { channelId: ANDROID_CHANNEL_ID } : {}),
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
+        weekday,
+        hour,
+        minute,
+      } as any,
+    });
+
+    await setSetting(BACKUP_REMINDER_ID_KEY, id);
+    console.log(`[Notifications] Backup reminder scheduled (weekday ${weekday}, ${time}, id: ${id})`);
+  } catch (err) {
+    console.warn('[Notifications] scheduleBackupReminder failed:', err);
+  }
+}
+
+/**
+ * Cancel the previously scheduled backup reminder (if any).
+ * Silently succeeds when no reminder was previously scheduled.
+ */
+export async function cancelBackupReminder(): Promise<void> {
+  try {
+    const id = await getSetting(BACKUP_REMINDER_ID_KEY);
+    if (id) {
+      await Notifications.cancelScheduledNotificationAsync(id);
+      await setSetting(BACKUP_REMINDER_ID_KEY, '');
+      console.log(`[Notifications] Backup reminder cancelled (id: ${id})`);
+    }
+  } catch (err) {
+    console.warn('[Notifications] cancelBackupReminder failed:', err);
+  }
+}
+
 // ─── Reconcile ───────────────────────────────────────────────────────────────
 
 /**
@@ -435,6 +514,17 @@ export async function reconcileScheduledNotifications(): Promise<void> {
       } else {
         await cancelMealReminder(meal);
       }
+    }
+
+    // Backup reminder (#293)
+    const backupEnabled = await getBackupReminderEnabled();
+    const backupDay = await getBackupReminderDay();
+    const backupTime = await getBackupReminderTime();
+
+    if (backupEnabled) {
+      await scheduleBackupReminder(backupDay, backupTime);
+    } else {
+      await cancelBackupReminder();
     }
   } catch (err) {
     console.warn('[Notifications] reconcileScheduledNotifications failed:', err);


### PR DESCRIPTION
## Summary

Closes the backup loop with two complementary safety features.

### Part A — Auto-snapshot before restore

- Extracted `buildBackupPayload()` from `exportBackup` so the dump/serialize logic is shared rather than duplicated (`src/services/backup.ts`).
- `writeSafetySnapshot()` — writes a `healthtracker-pre-restore-<timestamp>.json` to `cacheDirectory` before any data is wiped in `importBackup`.
- `importBackup()` now accepts an `onSnapshotFailed` callback so the caller can prompt the user to abort or continue when the snapshot write fails.
- `RestoreResult` carries `safetySnapshotUri` so the SettingsScreen can offer to share it.
- New `shareFile()` helper wraps expo-sharing for the post-restore "Share safety copy" flow.
- Restore confirm dialog updated to mention the safety copy; success dialog offers to share it.

### Part B — Periodic backup reminder

- **`src/db/database.ts`**: `getBackupReminderEnabled` / `setBackupReminderEnabled`, `getBackupReminderDay` / `setBackupReminderDay`, `getBackupReminderTime` / `setBackupReminderTime` — KV store accessors, no schema migration.
- **`src/services/notifications.ts`**: `scheduleBackupReminder(day, time)` using the WEEKLY trigger + `mapWeekdayToExpo`; stable identifier `backup-reminder`; `cancelBackupReminder()`; `getBackupReminderIdentifier()` (exported for tests); `reconcileScheduledNotifications` extended to apply/cancel from saved settings.
- **`src/screens/SettingsScreen.tsx`**: "Backup reminder" section inside the existing "Data & backup" card — toggle (sky accent) + weekday chip selector (sky tint) + time stepper (`shield-checkmark-outline` icon). Consistent with the weekly cook-day pattern. All Verdure tokens, outline Ionicons, no raw hex.

### Tests

- `notifications.test.ts`: `getBackupReminderIdentifier` (stable, contains "backup", distinct from meal ids, default time parses correctly); smoke exports for `scheduleBackupReminder` / `cancelBackupReminder`.
- `backup.test.ts`: smoke exports for `buildBackupPayload`, `writeSafetySnapshot`, `shareFile`.

### Constraints met

- No new dependency (expo-notifications / expo-file-system / expo-sharing already installed).
- No schema migration (settings in the KV store).
- All 306 existing tests keep passing; `npm run typecheck` exits 0.

Closes #293