### PR TITLE
ci: tidy release APK build/publish workflow (#298)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# Never run two release builds at once. Queue them (don't cancel an in-flight
+# build) so every push to main still gets its own Release.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -24,7 +30,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -48,20 +54,27 @@ jobs:
       - name: Generate Release Notes
         id: notes
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # Only consider version tags, and list commits SINCE the last release
+          # (two-dot range) so the changelog is "what's new", not the full history.
+          PREV_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          echo "## Changes" > release-notes.md
           if [ -z "$PREV_TAG" ]; then
-            git log --oneline > release-notes.md
+            git log --oneline >> release-notes.md
           else
-            git log ${PREV_TAG}...HEAD --oneline > release-notes.md
+            git log "${PREV_TAG}..HEAD" --oneline >> release-notes.md
           fi
-          
+
           DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/v${{ github.run_number }}/app-release.apk"
           QR_CODE_URL="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${DOWNLOAD_URL}"
-          
-          echo "## Download APK" >> release-notes.md
-          echo "[Direct Download Link](${DOWNLOAD_URL})" >> release-notes.md
-          echo "### Scan to Install:" >> release-notes.md
-          echo "![QR Code](${QR_CODE_URL})" >> release-notes.md
+
+          {
+            echo ""
+            echo "## Download APK"
+            echo "[Direct Download Link](${DOWNLOAD_URL})"
+            echo ""
+            echo "### Scan to Install:"
+            echo "![QR Code](${QR_CODE_URL})"
+          } >> release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -70,5 +83,6 @@ jobs:
           name: Release v${{ github.run_number }}
           body_path: release-notes.md
           files: app-release.apk
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Tidies the existing release pipeline (`.github/workflows/release.yml`) without changing its trigger. It still builds the APK locally via EAS and publishes a GitHub Release tagged `v<run_number>` on every push to `main`.

### Changes

- **Concurrency guard** — `concurrency: { group: release-${{ github.ref }}, cancel-in-progress: false }`. If two merges land close together, the second release run **queues** instead of running an overlapping ~20-min EAS build / racing on release creation. `cancel-in-progress: false` guarantees every push to `main` still produces its own Release.
- **`actions/setup-java@v3` → `@v4`** — v3 runs on the deprecated Node 16 runtime (deprecation warnings, eventual breakage).
- **Changelog correctness** — `git describe --tags --abbrev=0 --match 'v*'` (only version tags) + a two-dot `PREV_TAG..HEAD` range, so the notes list commits **since the last release** rather than the full history; the commit list now sits under a `## Changes` heading.
- **Fail closed on a missing APK** — `fail_on_unmatched_files: true` on `softprops/action-gh-release`, so a Release is never published without its APK attached.

### Scope / non-goals

- **No trigger change** (per decision: keep auto-release on every merge to `main`).
- No new EAS profile, no dependency changes, no app code.
- `build-check.yml` (the PR build gate) is intentionally left untouched here.

### Verification

- YAML parses cleanly (1 job, 9 steps, concurrency block valid).
- This workflow only runs on push to `main`, so it can't execute in the PR; it'll run on the next merge to `main`. The diff is config-only and behavior-preserving aside from the four points above.

Closes #298